### PR TITLE
Better message if user passes URL w/ no scheme

### DIFF
--- a/flask_restful/types.py
+++ b/flask_restful/types.py
@@ -19,11 +19,18 @@ regex = re.compile(
 
 
 def url(value):
-    """
-    Parse a valid looking url
+    """Validate a URL.
+
+    :param string value: The URL to validate
+    :returns: The URL if valid.
+    :raises: ValueError
     """
     if not regex.search(value):
-        raise ValueError("{} is not a valid URL".format(value))
+        message = "{} is not a valid URL".format(value)
+        if regex.search("".join(['http://', value])):
+            message = ("{0} is not a valid url."
+                       " Perhaps you meant: http://{0}".format(value))
+        raise ValueError(message)
     return value
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,5 @@
+# Running the tests
+
+Go up a directory and run:
+
+    $ make test


### PR DESCRIPTION
If it looks close to a URL, let's display a more informative error message
prompting them to add a scheme. If it's not close to a URL we just tell them
the URL is invalid.

Also add a README to the tests directory.

Tests:
No unit tests as only the error message is changing, not the validation logic. 
