### PR TITLE
Don't clobber app error handlers for non-API endpoints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     setup_requires=[
         'nose>=1.1.2',
         'mock>=0.8',
+        'blinker==1.2',
     ],
     install_requires=[
         'Flask>=0.8',


### PR DESCRIPTION
I'd like to suggest this changeset as a fix for [this](https://github.com/twilio/flask-restful/issues/8) issue, and I think it's generally a better idea than replacing the app's error handler for all endpoints.

This is somewhat related to [this](https://github.com/twilio/flask-restful/pull/9) pull request, which didn't really fix the bad beahviour, but at least made it optional.

I believe this changeset _can_ be merged as-is, I'm using it in my codebase and it works well for my needs. However, this is a tricky subject and Flask doesn't provide the exact APIs necessary to really hit the nail on the head, so I'm also proposing it as a basis to discussion. I'd love to hear what you think.
