### PR TITLE
Add custom marshalling hook for to_marshallable_type

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -43,6 +43,9 @@ def to_marshallable_type(obj):
     if hasattr(obj, '__getitem__'):
         return obj  # it is indexable it is ok
 
+    if hasattr(obj, '__marshallable__'):
+        return obj.__marshallable__()
+
     return dict(obj.__dict__)
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -12,6 +12,9 @@ from nose.tools import assert_equals # you need it for tests in form of continua
 class Foo(object):
     def __init__(self):
         self.hey = 3
+class Bar(object):
+    def __marshallable__(self):
+        return {"hey": 3}
 
 def check_field(expected, field, value):
     assert_equals(expected, field.output('a', {'a': value}))
@@ -231,6 +234,9 @@ class FieldsTestCase(unittest.TestCase):
         obj = {"hey": 3}
         self.assertEquals(obj, fields.to_marshallable_type(Foo()))
 
+    def test_to_dict_custom_marshal(self):
+        obj = {"hey": 3}
+        self.assertEquals(obj, fields.to_marshallable_type(Bar()))
 
     def test_get_value(self):
         self.assertEquals(3, fields.get_value("hey", {"hey": 3}))


### PR DESCRIPTION
In issue [#20](https://github.com/twilio/flask-restful/issues/20) I described bad interaction between flask-restful and SQLAlchemy related objects. When serializing, flask-restful's `to_marshallable_type()` relies on an instance's **dict** to contain the necessary state for serialization, which isn't always enough and definitely isn't enough for freshly fetched SQLAlchemy instances with related attributes, as these are populated lazily in the instance by proxies in the object's class.

After further discussing the matter on SQLAlchemy's mailing [list](https://groups.google.com/d/topic/sqlalchemy/7XVtKUYcjok/discussion), I believe the only correct way to handle this is to make marshalling optionally customizable, which this patch proposes by adding a `__marshallable__` method to an instance (I'd go with any other name, I dislike the name myself).

I'd like to note here that alternative solutions could instead (or in addition) add introspection logic to `to_marshallable_type()`. For example, `return dict((key, getattr(obj, key)) for key in dir(obj))` will solve the particular poor interaction with SQLAlchemy. However, I believe any such added introspection power would add complexity while still not being 100% correct, a poor trade. Hence, I propose this patch for merge as is. 
