### PR TITLE
flask view arguments are no longer implicitly parsed by RequestParser

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -93,7 +93,11 @@ class Argument(object):
         for operator in self.operators:
             name = self.name + operator.replace("=", "", 1)
             if name in source:
-                values = source.getlist(name)
+                # Account for MultiDict and regular dict
+                if hasattr(source, "getlist"):
+                    values = source.getlist(name)
+                else:
+                    values = [source.get(name)]
 
                 for value in values:
                     if not self.case_sensitive:
@@ -155,12 +159,7 @@ class RequestParser(object):
         if req is None:
             req = request
 
-        if hasattr(req, 'view_args') and req.view_args is not None:
-            self.url_matches = req.view_args
-            namespace = self.namespace_class(req.view_args.iteritems())
-        else:
-            self.url_matches = {}
-            namespace = self.namespace_class()
+        namespace = self.namespace_class()
 
         for arg in self.args:
             namespace[arg.dest or arg.name] = arg.parse(req)

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -176,8 +176,17 @@ class ReqParseTestCase(unittest.TestCase):
         req = Mock()
         req.view_args = {"foo": "bar"}
         parser = RequestParser()
+        parser.add_argument("foo", location="view_args", type=str)
         args = parser.parse_args(req)
         self.assertEquals(args['foo'], "bar")
+
+        req = Mock()
+        req.values = ()
+        req.view_args = {"foo": "bar"}
+        parser = RequestParser()
+        parser.add_argument("foo", type=str)
+        args = parser.parse_args(req)
+        self.assertEquals(args["foo"], None)
 
 
     def test_parse_unicode(self):


### PR DESCRIPTION
RequestParser no longer implicitly injects flask view arguments. As all other request arguments need to be explicitly declared via an Argument's location, I feel this violates the design of the module.
