### PR TITLE
allow adding arbitrary route kwargs to add_resource

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -101,6 +101,8 @@ class Api(object):
                          see: Fields
         :type endpoint: str
 
+        Additional keyword arguments not specified above will be passed as-is
+        to app.add_url_rule().
 
         Examples:
             api.add_resource(HelloWorld, '/', '/hello')
@@ -109,7 +111,7 @@ class Api(object):
             api.add_resource(FooSpecial, '/special/foo', endpoint="foo")
 
         """
-        endpoint = kwargs.get('endpoint') or resource.__name__.lower()
+        endpoint = kwargs.pop('endpoint', None) or resource.__name__.lower()
 
         if endpoint in self.app.view_functions.keys():
             previous_view_class = self.app.view_functions[endpoint].func_dict['view_class']
@@ -124,7 +126,7 @@ class Api(object):
 
 
         for url in urls:
-            self.app.add_url_rule(self.prefix + url, view_func=resource_func)
+            self.app.add_url_rule(self.prefix + url, view_func=resource_func, **kwargs)
 
     def output(self, resource):
         """Wraps a resource (as a flask view function), for cases where the

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -381,6 +381,16 @@ class APITestCase(unittest.TestCase):
         app.add_url_rule.assert_called_with('/foo',
             view_func=api.output())
 
+    def test_add_resource_kwargs(self):
+        app = Mock()
+        app.view_functions = {}
+        api = flask_restful.Api(app)
+        api.output = Mock()
+        api.add_resource(views.MethodView, '/foo', defaults={"bar": "baz"})
+
+        app.add_url_rule.assert_called_with('/foo',
+            view_func=api.output(), defaults={"bar": "baz"})
+
 
     def test_output_unpack(self):
 


### PR DESCRIPTION
In the usecase where I ran into `add_resource` not passing kwargs to `add_url_rule`, I wanted to use the same resource on several URLs with different `defaults` arguments, but I think the general case (just pass everything downwards to `add_url_rule`) is more flexible and least-surprising, being that the two methods are somewhat similar anyway.
