### PR TITLE
Fix incorrectly formatted err message

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -102,15 +102,15 @@ class List(Raw):
         super(List, self).__init__()
         if isinstance(cls_or_instance, type):
             if not issubclass(cls_or_instance, Raw):
-                raise MarshallingException("The type of the list elements \
-                                           must be a subclass of \
-                                           flask_restful.fields.Raw")
+                raise MarshallingException("The type of the list elements "
+                                           "must be a subclass of "
+                                           "flask_restful.fields.Raw")
             self.container = cls_or_instance()
         else:
             if not isinstance(cls_or_instance, Raw):
-                raise MarshallingException("The instances of the list \
-                                            elements must be of type \
-                                            flask_restful.fields.Raw")
+                raise MarshallingException("The instances of the list "
+                                           "elements must be of type "
+                                           "flask_restful.fields.Raw")
             self.container = cls_or_instance
 
     def output(self, key, data):


### PR DESCRIPTION
Literal strings in Python are joined implicitly. Escaping the newline character and leaving the string open leads to an error message with a lot of spaces in it (bad).
