### PR TITLE
Fix error handler for exceptions that do not have a message

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -68,7 +68,12 @@ class Api(object):
                           for rule in self.app.url_map.iter_rules()])
             close_matches = difflib.get_close_matches(request.path, rules.keys())
             if close_matches:
-                data['message'] += '. You have requested this URI [' + request.path + \
+                # If we already have a message, add punctuation and continue it.
+                if "message" in data:
+                    data["message"] += ". "
+                else:
+                    data["message"] = ""
+                data['message'] += 'You have requested this URI [' + request.path + \
                                    '] but did you mean ' + \
                                    ' or '.join((rules[match]
                                    for match in close_matches)) + ' ?'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -282,6 +282,14 @@ class APITestCase(unittest.TestCase):
                 "status": 404, "message": "Not Found. You have requested this URI [/fOo] but did you mean /foo ?",
             }))
 
+        with app.test_request_context("/fOo"):
+            del exception.data["message"]
+            resp = api.handle_error(exception)
+            self.assertEquals(resp.status_code, 404)
+            self.assertEquals(resp.data, dumps({
+                "status": 404, "message": "You have requested this URI [/fOo] but did you mean /foo ?",
+            }))
+
 
     def test_media_types(self):
         app = Flask(__name__)


### PR DESCRIPTION
The error handler assumes data will always have a "message" key, which might not always be true.
