### PR TITLE
action='append' should always return a list

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -122,6 +122,9 @@ class Argument(object):
         if not results:
             return self.default
 
+        if self.action == 'append':
+            return results
+
         if self.action == 'store' or len(results) == 1:
             return results[0]
         return results

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -238,6 +238,15 @@ class ReqParseTestCase(unittest.TestCase):
         args = parser.parse_args(req)
         self.assertEquals(args['foo'], ["bar", "bat"])
 
+    def test_parse_append_single(self):
+        req = Request.from_values("/bubble?foo=bar")
+
+        parser = RequestParser()
+        parser.add_argument("foo", action="append"),
+
+        args = parser.parse_args(req)
+        self.assertEquals(args['foo'], ["bar"])
+
 
     def test_parse_dest(self):
         req = Request.from_values("/bubble?foo=bar")
@@ -300,7 +309,7 @@ class ReqParseTestCase(unittest.TestCase):
         parser.add_argument("foo", operators=["<=", "="], action="append")
 
         args = parser.parse_args(Request.from_values("/bubble?foo<=bar"))
-        self.assertEquals(args['foo'], "bar")
+        self.assertEquals(args['foo'], ["bar"])
 
 
     def test_parse_lte_gte_missing(self):


### PR DESCRIPTION
Currently when you use action='append' in the request parser, it will return a list unless it's a single value.  This causes you to write type checking code for mixed return types.  python argparse doesn't do this, so I've updated flask-restful to match this behavior. 
