### PR TITLE
Add @parse_with to reqparse

### DIFF
--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -4,7 +4,11 @@ from mock import Mock, patch
 from flask import Flask
 from werkzeug import exceptions
 from werkzeug.wrappers import Request
-from flask_restful.reqparse import Argument, RequestParser, Namespace
+from flask_restful.reqparse import Argument, RequestParser, Namespace, parse_with
+
+class MockParser(object):
+    def parse_args(self):
+        return 'RESULTS'
 
 class ReqParseTestCase(unittest.TestCase):
     def test_default_help(self):
@@ -457,6 +461,43 @@ class ReqParseTestCase(unittest.TestCase):
     def test_namespace_configurability(self):
         self.assertTrue(isinstance(RequestParser().parse_args(), Namespace))
         self.assertTrue(type(RequestParser(namespace_class=dict).parse_args()) is dict)
+
+    def test_parse_with_for_functions(self):
+        @parse_with(MockParser())
+        def foo(result):
+            self.assertEquals(result, 'RESULTS')
+        @parse_with(MockParser())
+        def bar(result, argument):
+            self.assertEquals(result, 'RESULTS')
+            self.assertEquals(argument, 'ARGUMENT')
+        foo()
+        bar('ARGUMENT')
+
+    def test_parse_with_for_methods(self):
+        class Spam(object):
+            @parse_with(MockParser())
+            def foo(inner_self, result):
+                self.assertEquals(result, 'RESULTS')
+                return inner_self
+            @parse_with(MockParser())
+            def bar(inner_self, result, argument):
+                self.assertEquals(result, 'RESULTS')
+                self.assertEquals(argument, 'ARGUMENT')
+                return inner_self
+            @parse_with(MockParser())
+            @classmethod
+            def qux(cls, result):
+                self.assertEquals(result, 'RESULTS')
+                return cls
+            @parse_with(MockParser())
+            @staticmethod
+            def quux(result, argument):
+                self.assertEquals(result, 'RESULTS')
+        instance = Spam()
+        self.assertTrue(instance.foo() is instance)
+        self.assertTrue(instance.bar('ARGUMENT') is instance)
+        self.assertTrue(Spam.qux() is Spam)
+        instance.quux('ARGUMENT')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This decorator allows you to easily augment any function (typically a view
method) to access reqparse based arguments, i.e.:

```
class Users(Resource):
    @parse_with(RequestParser().add_argument('profession'))
    def post(self, params, username):
        create_new_user(username, params.profession)
        return 'CREATED', 201

api.add_resource(Users, '/<username>', endpoint='users')
```

The decorator is fairly magical in order to be able to decorate methods,
classmethods, staticmethods and plain functions. Rather than wrapping
the decorated function with another function, it wraps it with an
autogenerated callable descriptor that detects the invocation context
(function, method, etc) and alters the wrapped function's arguments
accordingly.

The descriptor assumes the wrapped function's name, docstring and module
string, what `@functools.wraps(f)` usually takes care of.
