### PR TITLE
setup.py optionaly require crypto module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ setup(
     ],
     install_requires=[
         'Flask>=0.8',
-        'pycrypto>=2.6',
-    ]
+    ],
+    extras_require = {
+        'paging':  ['pycrypto>=2.6'],
+    }
 )


### PR DESCRIPTION
I use flask on pypy.
However I cannot build pycrypto for pypy.
As I can see, only paging.py requires utils/crypto.py module.
I created "optional-pycrypto" branch that only changes setup.py file.
