### PR TITLE
Fix for #54, marshal_with working with response tuples

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -312,5 +312,10 @@ class marshal_with(object):
     def __call__(self, f):
         @wraps(f)
         def wrapper(*args, **kwargs):
-            return marshal(f(*args, **kwargs), self.fields)
+            resp = f(*args, **kwargs)
+            if isinstance(resp, tuple):
+                (data, code, headers) = unpack(resp)
+                return (marshal(data, self.fields), code, headers)
+            else:
+                return marshal(resp, self.fields)
         return wrapper

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -96,6 +96,14 @@ class APITestCase(unittest.TestCase):
             return {'foo': 'bar', 'bat': 'baz'}
         self.assertEquals(try_me(), {'foo': 'bar'})
 
+    def test_marshal_decorator_tuple(self):
+        fields = {'foo': flask_restful.fields.Raw}
+
+        @flask_restful.marshal_with(fields)
+        def try_me():
+            return {'foo': 'bar', 'bat': 'baz'}, 200, {'X-test': 123}
+        self.assertEquals(try_me(), ({'foo': 'bar'}, 200, {'X-test': 123}))
+
     def test_marshal_field(self):
         fields = {'foo': flask_restful.fields.Raw()}
         output = flask_restful.marshal({'foo': 'bar', 'bat': 'baz'}, fields)


### PR DESCRIPTION
Fix #54, allow marshal_with to be used with responses that are tuples of (data, code, headers)

Includes unit test addition.
