### PR TITLE
Add prettyprinting for JSON

### DIFF
--- a/flask_restful/representations/json.py
+++ b/flask_restful/representations/json.py
@@ -1,10 +1,30 @@
 from __future__ import absolute_import
-from flask import make_response
+from flask import make_response, current_app
 from json import dumps
+
+
+# This dictionary contains any kwargs that are to be passed to the json.dumps
+# function, used below.
+settings = {}
 
 
 def output_json(data, code, headers=None):
     """Makes a Flask response with a JSON encoded body"""
-    resp = make_response(dumps(data), code)
+
+    # If we're in debug mode, and the indent is not set, we set it to a
+    # reasonable value here.  Note that this won't override any existing value
+    # that was set.  We also set the "sort_keys" value.
+    local_settings = settings.copy()
+    if current_app.debug:
+        local_settings.setdefault('indent', 4)
+        local_settings.setdefault('sort_keys', True)
+
+    # We also add a trailing newline to the dumped JSON if the indent value is
+    # set - this makes using `curl` on the command line much nicer.
+    dumped = dumps(data, **local_settings)
+    if 'indent' in local_settings:
+        dumped += '\n'
+
+    resp = make_response(dumped, code)
     resp.headers.extend(headers or {})
     return resp


### PR DESCRIPTION
This commit adds prettyprinting to JSON output:
1. It creates a `settings` dict in the JSON representation module that contains kwargs to be passed to `json.dumps`
2. When the app is in debug mode (`app.debug` is True), then the representation will set reasonable defaults for prettyprinting JSON - specifically, indenting by 4 spaces and sorting by keys.  Note that both of these values will not be set if there is an existing setting for them.

Tests are also added.

Ref: #70

I didn't add documentation, since I wasn't really sure where to put it.  I'd be happy to add it if you have a preferred location.
