### PR TITLE
Skip not required attributes from args namespace.

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -184,6 +184,10 @@ class RequestParser(object):
         namespace = self.namespace_class()
 
         for arg in self.args:
-            namespace[arg.dest or arg.name] = arg.parse(req)
+            arg_value = arg.parse(req)
+            if not arg.required and arg_value is None:
+                continue
+            else:
+                namespace[arg.dest or arg.name] = arg_value
 
         return namespace


### PR DESCRIPTION
Skip the attribute on the resulting dictionary if the attribute is not passed on the request and also is flagged as required=False.

Useful to prevent raise NoneType exceptions on declared but not present values on the request.
