### PR TITLE
Fix bug when a non-dict was marshalled with a fields.List.

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -117,12 +117,12 @@ class List(Raw):
             self.container = cls_or_instance
 
     def output(self, key, data):
-        value = data[key]
+        value = get_value(key if self.attribute is None else self.attribute, data)
         # we cannot really test for external dict behavior
         if is_indexable_but_not_string(value) and not isinstance(value, dict):
             # Convert all instances in typed list to container type
-            return [self.container.output(idx, data[key]) for idx, val
-                    in enumerate(data[key])]
+            return [self.container.output(idx, value) for idx, val
+                    in enumerate(value)]
 
         return [marshal(value, self.container.nested)]
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -249,5 +249,18 @@ class FieldsTestCase(unittest.TestCase):
     def test_get_value_obj(self):
         self.assertEquals(3, fields.get_value("hey", Foo()))
 
+    def test_list(self):
+        obj = {'list': ['a', 'b', 'c']}
+        field = fields.List(fields.String)
+        self.assertEquals(['a', 'b', 'c'], field.output('list', obj))
+
+    def test_list_from_object(self):
+        class TestObject(object):
+            def __init__(self, list):
+                self.list = list
+        obj = TestObject(['a', 'b', 'c'])
+        field = fields.List(fields.String)
+        self.assertEquals(['a', 'b', 'c'], field.output('list', obj))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
See added test.  Marshal was failing when marshaling a List field from an object without **getitem**.  This is because the fields.List.output was using simple item access rather than get_value.
