### PR TITLE
Fix error when marshalling null list.

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -136,6 +136,9 @@ class List(Raw):
             return [self.container.output(idx, value) for idx, val
                     in enumerate(value)]
 
+        if value is None:
+            return self.default
+
         return [marshal(value, self.container.nested)]
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -262,5 +262,13 @@ class FieldsTestCase(unittest.TestCase):
         field = fields.List(fields.String)
         self.assertEquals(['a', 'b', 'c'], field.output('list', obj))
 
+    def test_null_list(self):
+        class TestObject(object):
+            def __init__(self, list):
+                self.list = list
+        obj = TestObject(None)
+        field = fields.List(fields.String)
+        self.assertEquals(None, field.output('list', obj))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Found a bug in the List field when trying to marshal an object where the list was None.  Added a test and fix.
