### PR TITLE
Making default unicode type work with required arguments for "json" location.

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -75,10 +75,10 @@ class Argument(object):
     def convert(self, value, op):
         try:
             return self.type(value, self.name, op)
-        except TypeError:
+        except (TypeError, LookupError):
             try:
                 return self.type(value, self.name)
-            except TypeError:
+            except (TypeError, LookupError):
                 return self.type(value)
 
     def handle_validation_error(self, error):

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -230,8 +230,16 @@ class ReqParseTestCase(unittest.TestCase):
 
         parser = RequestParser()
         parser.add_argument("foo", location="json")
+        parser.add_argument('bar', required=True, location='json',
+                            help='Required string argument')
+        parser.add_argument('baz', type=int, required=True, location='json',
+                            help='Optional int argument')
 
-        with app.test_request_context('/bubble', method="post"):
+        with app.test_request_context(
+            '/bubble', method="post",
+            data=json.dumps({'bar': 'bar', 'baz': '10'}),
+            content_type='application/json'
+        ):
             args = parser.parse_args()
             self.assertEquals(args['foo'], None)
 


### PR DESCRIPTION
Argument `convert` method was raising an error when trying to convert a required argument to the default `unicode` type. This at least was happening for `json` location. 

I added `LookupError` to the list of handled exceptions, however it might be not the best way. `Argument` documentation mentions `ValidationError` that should be raised by the type converter but this class does not exist in the repo: https://github.com/twilio/flask-restful/blob/master/flask_restful/reqparse.py#L34
