### PR TITLE
Allow properties to be used with fields.Nested.

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -104,13 +104,11 @@ class Nested(Raw):
         super(Nested, self).__init__(**kwargs)
 
     def output(self, key, obj):
-        data = to_marshallable_type(obj)
-
-        attr = key if self.attribute is None else self.attribute
-        if self.allow_null and data.get(attr) is None:
+        value = get_value(key if self.attribute is None else self.attribute, obj)
+        if self.allow_null and value is None:
             return None
 
-        return marshal(data[attr], self.nested)
+        return marshal(value, self.nested)
 
 class List(Raw):
     def __init__(self, cls_or_instance):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -171,6 +171,23 @@ class APITestCase(unittest.TestCase):
                                          {'blah': 'cool'}}], fields)
         self.assertEquals(output, [{'fee': {'blah': 'cool', 'fye': None}, 'foo': 'bar'}])
 
+    def test_marshal_nested_property(self):
+        class TestObject(object):
+            @property
+            def fee(self):
+                return {'blah': 'cool'}
+        fields = {
+            'foo': flask_restful.fields.Raw,
+            'fee': flask_restful.fields.Nested({
+                'fye': flask_restful.fields.String,
+                'blah': flask_restful.fields.String,
+            }, allow_null=True)
+        }
+        obj = TestObject()
+        obj.foo = 'bar'
+        obj.bat = 'baz'
+        output = flask_restful.marshal([obj], fields)
+        self.assertEquals(output, [{'fee': {'blah': 'cool', 'fye': None}, 'foo': 'bar'}])
 
     def test_marshal_list(self):
         fields = {


### PR DESCRIPTION
Fix bug that prevented `fields.Nested` from picking up values that are properties on the object being marshalled.
