### PR TITLE
Add the ability to marshall nested properties

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -24,6 +24,21 @@ def is_indexable_but_not_string(obj):
 
 def get_value(key, obj, default=None):
     """Helper for pulling a keyed value off various types of objects"""
+    if type(key) == int:
+        return _get_value_for_key(key, obj, default)
+    else:
+        return _get_value_for_keys(key.split('.'), obj, default)
+
+
+def _get_value_for_keys(keys, obj, default):
+    if len(keys) == 1:
+        return _get_value_for_key(keys[0], obj, default)
+    else:
+        return _get_value_for_keys(
+            keys[1:], _get_value_for_key(keys[0], obj, default), default)
+
+
+def _get_value_for_key(key, obj, default):
     if is_indexable_but_not_string(obj):
         try:
             return obj[key]

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -113,6 +113,15 @@ class FieldsTestCase(unittest.TestCase):
         self.assertEquals(field.output("foo", obj), 3)
 
 
+    def test_nested_raw_field(self):
+        foo = Mock()
+        bar = Mock()
+        bar.value = 3
+        foo.bar = bar
+        field = fields.Raw()
+        self.assertEquals(field.output("bar.value", foo), 3)
+
+
     def test_formatted_string_invalid_obj(self):
         field = fields.FormattedString("{hey}")
         self.assertRaises(MarshallingException, lambda: field.output("hey", None))


### PR DESCRIPTION
Hi, first of all, thanks for a great library.

This pull request adds a thing that I've wanted several times when marshalling a model that contains rich data structures on some of it's properties.

This allows for flattening out a nested object's value when marshalling it. It allows for keys like `foo.bar.baz` where the field will fetch the value for `baz` out of the `bar` object that is nested inside `foo`.

What do you guys think of this? Cheers!
