### PR TITLE
add callable location

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -63,11 +63,15 @@ class Argument(object):
         """
         if isinstance(self.location, six.string_types):
             value = getattr(request, self.location, MultiDict())
+            if callable(value):
+                value = value()
             if value is not None:
                 return value
         else:
             for l in self.location:
                 value = getattr(request, l, None)
+                if callable(value):
+                    value = value()
                 if value is not None:
                     return value
 


### PR DESCRIPTION
In flask==0.10 added get_json request argument which will remove json in future: http://flask.pocoo.org/docs/api/#flask.Request.json.
It also can be actual for another location in 0.10.
Perhaps my test for check callable with get_json will fail for flask==0.9 and less.
