### PR TITLE
Allow field type Fixed to take an attribute argument

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -125,6 +125,7 @@ class Nested(Raw):
 
         return marshal(value, self.nested)
 
+
 class List(Raw):
     def __init__(self, cls_or_instance):
         super(List, self).__init__()
@@ -245,9 +246,10 @@ class DateTime(Raw):
 
 ZERO = MyDecimal()
 
+
 class Fixed(Raw):
-    def __init__(self, decimals=5):
-        super(Fixed, self).__init__()
+    def __init__(self, decimals=5, **kwargs):
+        super(Fixed, self).__init__(**kwargs)
         self.precision = MyDecimal('0.' + '0' * (decimals - 1) + '1')
 
     def format(self, value):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -154,7 +154,6 @@ class FieldsTestCase(unittest.TestCase):
         with app.test_request_context("/"):
             self.assertEquals("/3", field.output("hey", Foo()))
 
-
     def test_int(self):
         field = fields.Integer()
         self.assertEquals(3, field.output("hey", {'hey': 3}))
@@ -211,6 +210,10 @@ class FieldsTestCase(unittest.TestCase):
     def test_advanced_fixed(self):
         field = fields.Fixed()
         self.assertRaises(MarshallingException, lambda: field.output("hey", {'hey': 'NaN'}))
+
+    def test_fixed_with_attribute(self):
+        field = fields.Fixed(4, attribute="bar")
+        self.assertEquals('3.0000', field.output("foo", {'bar': '3'}))
 
 
     def test_string(self):


### PR DESCRIPTION
Make the Fixed field type behave like most other field types by allowing it to use a specified attribute
