### PR TITLE
Allow exception propagation when app.propagate_exceptions is set

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -154,18 +154,17 @@ class Api(object):
         """
         got_request_exception.send(self.app, exception=e)
 
+        if not hasattr(e, 'code') and self.app.propagate_exceptions:
+            exc_type, exc_value, tb = sys.exc_info()
+            if exc_value is e:
+                exc = exc_type(exc_value)
+                exc.__traceback__ = tb
+                raise exc
+            else:
+                raise e
+
         code = getattr(e, 'code', 500)
         data = getattr(e, 'data', error_data(code))
-
-        if code == 500:
-            if self.app.propagate_exceptions:
-                exc_type, exc_value, tb = sys.exc_info()
-                if exc_value is e:
-                    exc = exc_type(exc_value)
-                    exc.__traceback__ = tb
-                    raise exc
-                else:
-                    raise e
 
         if code >= 500:
 


### PR DESCRIPTION
Added a check in `Api.handle_error` that propagates exceptions when `Flask.propagate_exceptions` is set. This honors the `app.testing` setting as established at http://flask.pocoo.org/docs/api/#flask.Flask.test_client that propagates exceptions instead of returning Flask responses. Otherwise behavior is inconsistent with Flask and testing is harder.

In general it would be nice to use Flask's error handlers instead of hacking a level above them, this would alleviate having to place another check (propagate_exceptions is already checked in flask). I am not sure if the handlers are
good enough to support wrapping all exceptions into json responses though.
