### PR TITLE
Update Blinker dependency to >=1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         'nose>=1.1.2',
         'mock>=0.8',
         'six>=1.3.0',
-        'blinker==1.2',
+        'blinker>=1.2',
     ],
     install_requires=[
         'Flask>=0.8',


### PR DESCRIPTION
The dependency on 1.2 is incompatible with other popular Flask extensions, including Flask-Security.  See issue #117.  All tests pass with 1.3 installed instead.
