### PR TITLE
Add code required to subclass Api in the Response Formats example

### DIFF
--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -130,7 +130,7 @@ provide your own output functions. ::
 
     class Api(restful.Api):
         def __init__(self, *args, **kwargs):
-            restful.Api.__init__(self, *args, **kwargs)
+            super(Api, self).__init__(*args, **kwargs)
             self.representations = {
                 'application/xml': output_xml,
                 'text/html': output_html,


### PR DESCRIPTION
Maybe it's obvious for some but it can help new users to know they need to do that for the example to work, otherwise it will silently ignore the `representations` assignment.
