### PR TITLE
allow overriding default response for failed auth

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -7,7 +7,7 @@ from flask.views import MethodView
 from flask.signals import got_request_exception
 from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound
 from werkzeug.http import HTTP_STATUS_CODES
-from flask.ext.restful.utils import unauthorized, error_data, unpack
+from flask.ext.restful.utils import error_data, unpack
 from flask.ext.restful.representations.json import output_json
 import sys
 
@@ -195,8 +195,7 @@ class Api(object):
         resp = self.make_response(data, code)
 
         if code == 401:
-            resp = unauthorized(resp,
-                self.app.config.get("HTTP_BASIC_AUTH_REALM", "flask-restful"))
+            resp = self.unauthorized(resp)
 
         return resp
 
@@ -268,7 +267,7 @@ class Api(object):
     def url_for(self, resource, **values):
         """Generates a URL to the given resource."""
         return url_for(resource.endpoint, **values)
-        
+
     def make_response(self, data, *args, **kwargs):
         """Looks up the representation transformer for the requested media
         type, invoking the transformer to create a response object. This
@@ -312,6 +311,15 @@ class Api(object):
             self.representations[mediatype] = func
             return func
         return wrapper
+
+    def unauthorized(self, response):
+        """ Given a response, change it to ask for credentials"""
+
+        realm = self.app.config.get("HTTP_BASIC_AUTH_REALM", "flask-restful")
+        challenge = u"{0} realm=\"{1}\"".format("Basic", realm)
+
+        response.headers['WWW-Authenticate'] = challenge
+        return response
 
 
 class Resource(MethodView):

--- a/flask_restful/utils/__init__.py
+++ b/flask_restful/utils/__init__.py
@@ -4,18 +4,6 @@ def http_status_message(code):
     """Maps an HTTP status code to the textual status"""
     return HTTP_STATUS_CODES.get(code, '')
 
-
-def challenge(authentication, realm):
-    """Constructs the string to be sent in the WWW-Authenticate header"""
-    return u"{0} realm=\"{1}\"".format(authentication, realm)
-
-
-def unauthorized(response, realm):
-    """ Given a response, change it to ask for credentials"""
-    response.headers['WWW-Authenticate'] = challenge("Basic", realm)
-    return response
-
-
 def error_data(code):
     """Constructs a dictionary with status and message for returning in an
     error response"""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,7 @@ except:
     from unittest.mock import Mock, patch
 import flask
 import werkzeug
-from flask.ext.restful.utils import http_status_message, challenge, unauthorized, error_data, unpack
+from flask.ext.restful.utils import http_status_message, error_data, unpack
 import flask_restful
 import flask_restful.fields
 from flask_restful import OrderedDict
@@ -39,22 +39,23 @@ class APITestCase(unittest.TestCase):
         self.assertEquals(http_status_message(404), 'Not Found')
 
 
-    def test_challenge(self):
-        self.assertEquals(challenge('Basic', 'Foo'), 'Basic realm="Foo"')
-
-
     def test_unauthorized(self):
+        app = Flask(__name__)
+        api = flask_restful.Api(app)
         response = Mock()
         response.headers = {}
-        unauthorized(response, "flask-restful")
+        response = api.unauthorized(response)
         self.assertEquals(response.headers['WWW-Authenticate'],
                       'Basic realm="flask-restful"')
 
 
     def test_unauthorized_custom_realm(self):
+        app = Flask(__name__)
+        app.config['HTTP_BASIC_AUTH_REALM'] = 'Foo'
+        api = flask_restful.Api(app)
         response = Mock()
         response.headers = {}
-        unauthorized(response, realm='Foo')
+        response = api.unauthorized(response)
         self.assertEquals(response.headers['WWW-Authenticate'], 'Basic realm="Foo"')
 
 
@@ -660,7 +661,7 @@ class APITestCase(unittest.TestCase):
         with app.test_request_context('/ids/3'):
             self.assertTrue(api._has_fr_route())
 
-            
+
     def test_url_for(self):
         app = Flask(__name__)
         api = flask_restful.Api(app)
@@ -668,7 +669,7 @@ class APITestCase(unittest.TestCase):
         with app.test_request_context('/foo'):
             self.assertEqual(api.url_for(HelloWorld, id = 123), '/ids/123')
 
-            
+
     def test_fr_405(self):
         app = Flask(__name__)
         api = flask_restful.Api(app)


### PR DESCRIPTION
Fixes #83.

When `abort(401)` is called it constructs the response by calling `utils.unauthorized`. This pull moves `unauthorized` onto the `Api` object so it can be overridden.
#### Example Usage

Subclass `restful.Api`:

``` python
class Api(restful.Api):
    def unauthorized(self, response):
        data = {'error': 'Authorization failed'}
        return make_response(data)
```

Or manually set it:

``` python
def custom_unauthorized(response):
    data = {"error": "Authorization failed"}
    return make_response(data)

app = Flask(__name__)
api = restful.Api(app)
api.unauthorized = custom_unauthorized
```
