### PR TITLE
fields.Url() should return an external URL

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -124,7 +124,7 @@ your data object. ::
 
 
 By default ``fields.Url`` returns a relative uri. To generate an absolute uri that includes
-the scheme, hostname and port pass ``external = True`` in the field declaration. ::
+the scheme, hostname and port pass ``absolute = True`` in the field declaration. ::
 
     fields = {
         'uri': fields.Url('todo_resource', external = True)

--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -204,16 +204,16 @@ class Url(Raw):
     """
     A string representation of a Url
     """
-    def __init__(self, endpoint, external = False):
+    def __init__(self, endpoint, absolute = False):
         super(Url, self).__init__()
         self.endpoint = endpoint
-        self.external = external
+        self.absolute = absolute
 
     def output(self, key, obj):
         try:
             data = to_marshallable_type(obj)
-            o = urlparse(url_for(self.endpoint, _external = self.external, **data))
-            if self.external:
+            o = urlparse(url_for(self.endpoint, _external = self.absolute, **data))
+            if self.absolute:
                 return urlunparse((o.scheme, o.netloc, o.path, "", "", ""))
             return urlunparse(("", "", o.path, "", "", ""))
         except TypeError as te:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -155,10 +155,10 @@ class FieldsTestCase(unittest.TestCase):
             self.assertEquals("/3", field.output("hey", Foo()))
 
 
-    def test_url_external(self):
+    def test_url_absolute(self):
         app = Flask(__name__)
         app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
-        field = fields.Url("foobar", external = True)
+        field = fields.Url("foobar", absolute = True)
 
         with app.test_request_context("/"):
             self.assertEquals("http://localhost/3", field.output("hey", Foo()))


### PR DESCRIPTION
Doesn't it make more sense this way? In pretty much all cases the URLs will go out in a JSON blob to the client, so they should be formatted as external URLs.
