### PR TITLE
JSON null string argument should be left as None not casted to 'None'

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -78,6 +78,10 @@ class Argument(object):
         return MultiDict()
 
     def convert(self, value, op):
+        # check if we're expecting a string and the value is `None`
+        if value is None and issubclass(self.type, six.string_types):
+            return None
+            
         try:
             return self.type(value, self.name, op)
         except TypeError:


### PR DESCRIPTION
Given the following request body:

``` json
{
  "stuff": null
}
```

And the following parser:

``` python
parser = RequestParser()
parser.add_argument('stuff', type=str, location='json')
```

The parser will convert `stuff` to `'None'` since `str(None) == 'None'` instead of leaving it as `None`.

The `convert` method of the `Argument` class should first check if the value is `None` and the expected type is a subclass of `basestring` and leave the value as `None`.
