### PR TITLE
Avoid unicode LookupError

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -21,10 +21,12 @@ _friendly_location = {
     u'files': u'an uploaded file',
 }
 
+text_type = lambda x: six.text_type(x)
+
 class Argument(object):
 
     def __init__(self, name, default=None, dest=None, required=False,
-                 ignore=False, type=six.text_type, location=('json', 'values',),
+                 ignore=False, type=text_type, location=('json', 'values',),
                  choices=(), action='store', help=None, operators=('=',),
                  case_sensitive=True):
         """

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -127,9 +127,12 @@ class ReqParseTestCase(unittest.TestCase):
         self.assertEquals(arg.operators[0], "=")
         self.assertEquals(len(arg.operators), 1)
 
-    def test_default_type(self):
+    @patch('flask_restful.reqparse.six')
+    def test_default_type(self, mock_six):
         arg = Argument("foo")
-        self.assertEquals(arg.type, six.text_type)
+        sentinel = object()
+        arg.type(sentinel)
+        mock_six.text_type.assert_called_with(sentinel)
 
 
     def test_default_default(self):


### PR DESCRIPTION
`six.text_type` is `unicode` on Python 2 and `str` on Python 3. Both of these
functions accept multiple parameters: the second is the `encoding` parameter.
[According to the documentation](http://docs.python.org/2/library/functions.html#unicode): "The encoding parameter is a string giving the
name of an encoding; if the encoding is not known, `LookupError` is raised."
Because `LookupError` does not inherit from `TypeError`, it is not caught by
the try/catch blocks, and can result in Flask-Restful returning a 400 status
code response.

This commit changes the default type to a wrapper around `six.text_type` that
only takes one parameter. This way, an encoding will never be specified, and it
will never raise a `LookupError`.
