### PR TITLE
Allow redirects through to user

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import difflib
 from functools import wraps, partial
 import re
-from flask import request, Response, url_for
+from flask import request, url_for
 from flask import abort as original_flask_abort
 from flask.views import MethodView
 from flask.signals import got_request_exception
@@ -383,7 +383,7 @@ class Api(object):
         @wraps(resource)
         def wrapper(*args, **kwargs):
             resp = resource(*args, **kwargs)
-            if isinstance(resp, Response) or isinstance(resp, ResponseBase):  # There may be a better way to test
+            if isinstance(resp, ResponseBase):  # There may be a better way to test
                 return resp
             data, code, headers = unpack(resp)
             return self.make_response(data, code, headers=headers)
@@ -473,7 +473,7 @@ class Resource(MethodView):
 
         resp = meth(*args, **kwargs)
 
-        if isinstance(resp, Response):  # There may be a better way to test
+        if isinstance(resp, ResponseBase):  # There may be a better way to test
             return resp
 
         representations = self.representations or {}


### PR DESCRIPTION
For some reason flask.redirect returns a response that is derived from werkzeug.wrappers.Response, rather than flask.Response. Testing with some dummy code proves this problem to be a bit inconsistent:

``` python
class X(object):
    def __init__(self):
        pass

class Y(X):
    def __init__(self):
        pass

z = Y()
isinstance(z, X)  #  -> True
```

This conflicts with what I see with Flask / Flask-Restful:

``` python
from flask import Response

#...blahblahblah basic setup
x = redirect(url_for('render_root'))
isinstance(x, Response)  #  -> False
```

The code on this branch fixes this, but there may be a better way to fix this problem. I'd be open to hearing and possibly implementing any other ideas. Do you guys have any other thoughts?
