### PR TITLE
Fixed bug with the output method of a List field

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -151,7 +151,7 @@ class List(Raw):
         # we cannot really test for external dict behavior
         if is_indexable_but_not_string(value) and not isinstance(value, dict):
             # Convert all instances in typed list to container type
-            return [self.container.output(idx, value) for idx, val
+            return [self.container.output(idx, val) for idx, val
                     in enumerate(value)]
 
         if value is None:


### PR DESCRIPTION
There is a bug with the output method of the List class. While iterating over the list the value assigned to the List class is passed to the container instead of the actual value of the element in the list.
