### PR TITLE
blueprint_setup.add_url_rule won't be called when add resource to an Api object with blueprint initialized

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -358,7 +358,7 @@ class Api(object):
                     # Set the rule to a string directly, as the blueprint is already
                     # set up.
                     self.blueprint_setup.add_url_rule(url, view_func=resource_func, **kwargs)
-                    return
+                    continue
                 else:
                     # Set the rule to a function that expects the blueprint prefix
                     # to construct the final url.  Allows deferment of url finalization


### PR DESCRIPTION
Fix the problem that blueprint_setup.add_url_rule won't be called when an flask.ext.restful.Api object initialized with a Blueprint object and the BlueprintState object was ready.
