### PR TITLE
Support callable default

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -164,7 +164,10 @@ class Argument(object):
             self.handle_validation_error(ValueError(error_msg))
 
         if not results:
-            return self.default
+            if callable(self.default):
+                return self.default()
+            else:
+                return self.default
 
         if self.action == 'append':
             return results

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -441,6 +441,16 @@ class ReqParseTestCase(unittest.TestCase):
         self.assertEquals(args['foo'], "bar")
 
 
+    def test_parse_callable_default(self):
+        req = Request.from_values("/bubble")
+
+        parser = RequestParser()
+        parser.add_argument("foo", default=lambda: "bar")
+
+        args = parser.parse_args(req)
+        self.assertEquals(args['foo'], "bar")
+
+
     def test_parse(self):
         req = Request.from_values("/bubble?foo=bar")
 


### PR DESCRIPTION
This is useful when the default value comes from current_app.config like this:

``` python
parser = reqparse.RequestParser()
parser.add_argument('foo', type=int,
                    default=lambda: current_app.config['DEFAULT_FOO'])
```
