### PR TITLE
Don't install 'tests' package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='Kyle Conroy',
     author_email='help@twilio.com',
     description='Simple framework for creating REST APIs',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     zip_safe=False,
     include_package_data=True,
     platforms='any',


### PR DESCRIPTION
Currently Flask-RESTful installs 'tests' pacakge in 'site-packages' directory.
