### PR TITLE
modified test_types.py to be compatible with python 3

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -335,7 +335,7 @@ def test_invalid_isointerval_error():
 
     error = cm.exception
     assert_equal(
-        error.message,
+        str(error),
         "Invalid argument: 2013-01-01/blah. argument must be a valid ISO8601 "
         "date/time interval.",
     )


### PR DESCRIPTION
Python 3 doesn't support Error.message, but both Python 2 and Python 3 support converting Error to string by str(err). tests.test_types.test_invalid_isointerval_error was failing in Python 3 before, but now it passes.
