### PR TITLE
Fix Missing `self.app`

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -84,7 +84,6 @@ class Api(object):
         self.app = None
 
         if app is not None:
-            self.app = app
             self.init_app(app)
 
     def init_app(self, app):
@@ -190,6 +189,8 @@ class Api(object):
         if len(self.resources) > 0:
             for resource, urls, kwargs in self.resources:
                 self._register_view(app, resource, *urls, **kwargs)
+
+        self.app = app
 
     def owns_endpoint(self, endpoint):
         """Tests if an endpoint name (not path) belongs to this Api.  Takes


### PR DESCRIPTION
When I try to migrate `flask-restful` to latest version, our project is down.
See traceback:

```
File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/usr/local/lib/python2.7/dist-packages/flask_restful/__init__.py", line 257, in error_router
    return self.handle_error(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask_restful/__init__.py", line 257, in error_router
    return self.handle_error(e)
  File "/usr/local/lib/python2.7/dist-packages/flask_restful/__init__.py", line 289, in handle_error
    help_on_404 = self.app.config.get("ERROR_404_HELP", True)
AttributeError: 'NoneType' object has no attribute 'config'
```

We init app through `init_app`:

``` python
api = API(catch_all_404s=True)
api.init_app(app)
```

Method `init_app` does not assign app to `self.app`.
