### PR TITLE
Keep traceback when an exception occurs in `abort`

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -34,7 +34,7 @@ def abort(http_status_code, **kwargs):
     except HTTPException as e:
         if len(kwargs):
             e.data = kwargs
-        raise e
+        raise
 
 DEFAULT_REPRESENTATIONS = {'application/json': output_json}
 


### PR DESCRIPTION
If `raise e`  is used in an `except` block, the exception traceback would only go to this statement, ignoring the original traceback, causing difficulty in debugging.
