### PR TITLE
If the user code raises a 400, don't try to override it.

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -108,8 +108,9 @@ class Argument(object):
 
         :param error: the error that was raised
         """
-        if error.code == 400:
-            raise
+        if getattr(error,'code',None):
+            if error.code == 400:
+                raise
         msg = self.help if self.help is not None else str(error)
         flask_restful.abort(400, message=msg)
 


### PR DESCRIPTION
I have a number of validators implemented as Argument `type`s to handle parameters values like `path?somelist=a,b,c` and `path?range=start:end`. if the validator fails, it raises a 400 with a contextual (rather than static, using `help`) error message. `handle_validation_error()` swallows these 400s, and this fix propagates them instead.
