### PR TITLE
use flask.json

### DIFF
--- a/flask_restful/representations/json.py
+++ b/flask_restful/representations/json.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from flask import make_response, current_app
-from json import dumps
+from flask.json import dumps
 
 
 # This dictionary contains any kwargs that are to be passed to the json.dumps

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -8,7 +8,7 @@ from werkzeug.datastructures import FileStorage
 from flask_restful.reqparse import Argument, RequestParser, Namespace
 import six
 
-import json
+from flask import json
 
 class ReqParseTestCase(unittest.TestCase):
     def test_default_help(self):


### PR DESCRIPTION
Fixes #207 by using `flask.json` instead of the regular `json` library.
