### PR TITLE
Fix UserDict import for Python 3 support

### DIFF
--- a/flask_restful/utils/ordereddict.py
+++ b/flask_restful/utils/ordereddict.py
@@ -20,7 +20,10 @@
 #     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 #     OTHER DEALINGS IN THE SOFTWARE.
 
-from UserDict import DictMixin
+try:
+    from UserDict import DictMixin
+except ImportError:
+    from collections import MutableMapping as DictMixin
 import six
 
 


### PR DESCRIPTION
As mentioned in #192, UserDict module doesn't exist in Python 3. Instead, collections.MutableMapping is imported in that environment. As this is just a fix for Python 3, no additional test included. Let me know if I should change something about that. Build passed at https://travis-ci.org/twilio/flask-restful/builds/24404738.

Thanks!
