### PR TITLE
fixes #53 by adding function to convert rfc822 string to datetime

### DIFF
--- a/flask_restful/types.py
+++ b/flask_restful/types.py
@@ -1,6 +1,6 @@
 from calendar import timegm
 from datetime import datetime, time, timedelta
-from email.utils import formatdate
+from email.utils import formatdate, parsedate_tz, mktime_tz
 import re
 
 import aniso8601
@@ -223,3 +223,17 @@ def rfc822(dt):
     :return: A RFC 822 formatted date string
     """
     return formatdate(timegm(dt.utctimetuple()))
+
+
+def datetime_from_rfc822(datetime_str):
+    """Turns an RFC822 formatted date into a datetime object.
+
+    Example::
+
+        types.datetime_from_rfc822("Wed, 02 Oct 2002 08:00:00 EST")
+
+    :param datetime_str: The RFC822-complying string to transform
+    :type datetime_str: str
+    :return: A datetime
+    """
+    return datetime.fromtimestamp(mktime_tz(parsedate_tz(datetime_str)), pytz.utc)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -38,6 +38,17 @@ def test_datetime_formatters():
         yield assert_equal, types.rfc822(date_obj), expected
 
 
+def test_reverse_datetime():
+    dates = [
+        ("Sat, 01 Jan 2011 00:00:00 -0000", datetime(2011, 1, 1, tzinfo=UTC())),
+        ("Sat, 01 Jan 2011 23:59:59 -0000", datetime(2011, 1, 1, 23, 59, 59, tzinfo=UTC())),
+        ("Sat, 01 Jan 2011 23:59:59 -0000", datetime(2011, 1, 1, 23, 59, 59, tzinfo=UTC())),
+    ]
+
+    for date_string, expected in dates:
+        yield assert_equal, types.datetime_from_rfc822(date_string), expected
+
+
 def test_urls():
     urls = [
         'http://www.djangoproject.com/',


### PR DESCRIPTION
Adds `datetime_from_rfc822` which takes an RFC822 formatted string and returns a datetime.
