### PR TITLE
fixes #174 by converting arguments before checking against choices

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -134,20 +134,23 @@ class Argument(object):
                     values = [source.get(name)]
 
                 for value in values:
-                    _is_file = isinstance(value, FileStorage)
-                    if not (self.case_sensitive or _is_file):
-                        value = value.lower()
-                    if self.choices and value not in self.choices:
-                        self.handle_validation_error(ValueError(
-                            u"{0} is not a valid choice".format(value)))
-                    if not _is_file:
+                    if not isinstance(value, FileStorage):
+                        if not self.case_sensitive:
+                            value = value.lower()
+
                         try:
                             value = self.convert(value, operator)
                         except Exception as error:
                             if self.ignore:
                                 continue
-
                             self.handle_validation_error(error)
+
+                        if self.choices and value not in self.choices:
+                            self.handle_validation_error(
+                                ValueError(u"{0} is not a valid choice".format(
+                                    value
+                                ))
+                            )
 
                     results.append(value)
 

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -543,5 +543,38 @@ class ReqParseTestCase(unittest.TestCase):
         args = parser.parse_args(req)
         self.assertEquals(args['foo'], u"bar")
 
+    def test_int_choice_types(self):
+        app = Flask(__name__)
+        parser = RequestParser()
+        parser.add_argument("foo", type=int, choices=[1, 2, 3], location='json')
+
+        with app.test_request_context(
+                '/bubble', method='post',
+                data=json.dumps({'foo': 5}),
+                content_type='application/json'
+        ):
+            try:
+                parser.parse_args()
+                self.fail()
+            except exceptions.BadRequest:
+                pass
+
+    def test_int_range_choice_types(self):
+        app = Flask(__name__)
+        parser = RequestParser()
+        parser.add_argument("foo", type=int, choices=range(100), location='json')
+
+        with app.test_request_context(
+                '/bubble', method='post',
+                data=json.dumps({'foo': 101}),
+                content_type='application/json'
+        ):
+            try:
+                parser.parse_args()
+                self.fail()
+            except exceptions.BadRequest:
+                pass
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We used to check the argument against the specified `choices` sequence before we converted it. This meant that arguments were always strings when compared to the `choices` dict, which led to having to do weird things like

```
parser.add_argument('foo', type='int', choices=['10', '20'])
```

This pull let's you do

```
parser.add_argument('foo', type='int', choices=[10, 20])
```

The change is that the choices list is the correct type.
