### PR TITLE
document FormattedString

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -212,7 +212,27 @@ class Boolean(Raw):
 
 
 class FormattedString(Raw):
+    """
+    FormattedString is used to interpolate other values from
+    the response into this field. The syntax for the source string is
+    the same as the string `format` method from the python stdlib.
+
+    Ex::
+
+        fields = {
+            'name': fields.String,
+            'greeting': fields.FormattedString("Hello {name}")
+        }
+        data = {
+            'name': 'Doug',
+        }
+        marshal(data, fields)
+    """
     def __init__(self, src_str):
+        """
+        :param string src_str: the string to format with the other
+        values from the response.
+        """
         super(FormattedString, self).__init__()
         self.src_str = six.text_type(src_str)
 


### PR DESCRIPTION
Fixes #215 by adding an example for how to use `FormattedString`.
