### PR TITLE
Fix POST/PUT with querystring

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -30,7 +30,7 @@ text_type = lambda x: six.text_type(x)
 class Argument(object):
 
     def __init__(self, name, default=None, dest=None, required=False,
-                 ignore=False, type=text_type, location=('json', 'values',),
+                 ignore=False, type=text_type, location=('values', 'json'),
                  choices=(), action='store', help=None, operators=('=',),
                  case_sensitive=True):
         """


### PR DESCRIPTION
After consuming JSON data it forgets querystring data.
