### PR TITLE
Initialize the blueprint attribute in the __init__ method

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -86,6 +86,7 @@ class Api(object):
         self.endpoints = set()
         self.resources = []
         self.app = None
+        self.blueprint = None
 
         if app is not None:
             self.app = app
@@ -106,7 +107,6 @@ class Api(object):
             api.init_app(app)
 
         """
-        self.blueprint = None
         # If app is a blueprint, defer the initialization
         try:
             app.record(self._deferred_blueprint_init)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -791,5 +791,14 @@ class APITestCase(unittest.TestCase):
             self.assertEquals(resp.status_code, 418)
             self.assertDictEqual(loads(resp.data), {"message": "api is foobar", "status": 418})
 
+    def test_calling_owns_endpoint_before_api_init(self):
+        api = flask_restful.Api()
+
+        try:
+            api.owns_endpoint('endpoint')
+        except AttributeError, ae:
+            self.fail(ae.message)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The `init_app()` method may not have been called before methods like `owns_endpoint()` is called which results in an AttributeError being thrown.
