### PR TITLE
Correctly convert decimal.Decimal when parsing POST args.

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -1,6 +1,7 @@
 from flask import request
 from werkzeug.datastructures import MultiDict, FileStorage
 import flask_restful
+import decimal
 import inspect
 import six
 
@@ -101,7 +102,10 @@ class Argument(object):
             return self.type(value, self.name, op)
         except TypeError:
             try:
-                return self.type(value, self.name)
+                if self.type is decimal.Decimal:
+                    return self.type(str(value), self.name)
+                else:
+                    return self.type(value, self.name)
             except TypeError:
                 return self.type(value)
 

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -7,6 +7,7 @@ from werkzeug.wrappers import Request
 from werkzeug.datastructures import FileStorage
 from flask_restful.reqparse import Argument, RequestParser, Namespace
 import six
+import decimal
 
 import json
 
@@ -519,6 +520,18 @@ class ReqParseTestCase(unittest.TestCase):
                 self.assertEquals(args['foo'], None)
             except exceptions.BadRequest:
                 self.fail()
+
+    def test_type_decimal(self):
+        app = Flask(__name__)
+
+        parser = RequestParser()
+        parser.add_argument("foo", type=decimal.Decimal, location="json")
+
+        with app.test_request_context('/bubble', method='post',
+                                      data=json.dumps({"foo": 1.0025}),
+                                      content_type='application/json'):
+            args = parser.parse_args()
+            self.assertEquals(args['foo'], decimal.Decimal("1.0025"))
 
     def test_type_filestorage(self):
         app = Flask(__name__)


### PR DESCRIPTION
Decimals are being marshalled correctly when being included as part of a response. It is also being parsed correctly when the arg is from a querystring. However, the decimal arg is not being parsed correctly when it is a part of a POST request's body because a float is being passed to Decimal, which loses precision after a Decimal is created. The problem exists on python2.x, but I believe it's already fixed on python3.x. This pull request fixes the problem by converting the float value to a string before passing it to the Decimal constructor. Very important when dealing with money.
