### PR TITLE
Add credentials kwarg to support CORS + basic auth

### DIFF
--- a/flask_restful/utils/cors.py
+++ b/flask_restful/utils/cors.py
@@ -5,7 +5,7 @@ from functools import update_wrapper
 
 def crossdomain(origin=None, methods=None, headers=None,
                 max_age=21600, attach_to_all=True,
-                automatic_options=True):
+                automatic_options=True, credentials=False):
     """
     http://flask.pocoo.org/snippets/56/
     """
@@ -39,6 +39,8 @@ def crossdomain(origin=None, methods=None, headers=None,
             h['Access-Control-Allow-Origin'] = origin
             h['Access-Control-Allow-Methods'] = get_methods()
             h['Access-Control-Max-Age'] = str(max_age)
+            if credentials:
+                h['Access-Control-Allow-Credentials'] = 'true'
             if headers is not None:
                 h['Access-Control-Allow-Headers'] = headers
             return resp


### PR DESCRIPTION
If we set the `withCredentials` flag on an XMLHttpRequest request:

```
xhr.withCredentials = true;
```

the browser will handle HTTP basic auth for us, presenting the usual username/password dialogue to the user and handling the subsequest authentication cookie. To show support for this, the server must respond with an additional CORS header:

```
Access-Control-Allow-Credentials : 'true'
```

See the ['withCredentials' section of this post](http://www.html5rocks.com/en/tutorials/cors/) for more details.

This PR simply adds a kwarg to the `crossdomain` decorator which adds this header if the user requests it (default to `False`)
