### PR TITLE
Fix Integer initialize for more flexible.

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -81,8 +81,8 @@ class Raw(object):
         self.default = default
 
     def format(self, value):
-        """Formats a field's value. No-op by default - field classes that 
-        modify how the value of existing object keys should be presented should 
+        """Formats a field's value. No-op by default - field classes that
+        modify how the value of existing object keys should be presented should
         override this and apply the appropriate formatting.
 
         :param value: The value to format
@@ -98,11 +98,11 @@ class Raw(object):
 
     def output(self, key, obj):
         """Pulls the value for the given key from the object, applies the
-        field's formatting and returns the result. If the key is not found 
-        in the object, returns the default value. Field classes that create 
-        values which do not require the existence of the key in the object 
+        field's formatting and returns the result. If the key is not found
+        in the object, returns the default value. Field classes that create
+        values which do not require the existence of the key in the object
         should override this and return the desired value.
-        
+
         :exception MarshallingException: In case of formatting problem
         """
 
@@ -194,8 +194,8 @@ class Integer(Raw):
         value, use this to retrieve a different attribute from the response
         than the publicly named value.
     """
-    def __init__(self, default=0, attribute=None):
-        super(Integer, self).__init__(default, attribute)
+    def __init__(self, default=0, **kwargs):
+        super(Integer, self).__init__(default=default, **kwargs)
 
     def format(self, value):
         try:


### PR DESCRIPTION
It's no use of `attribute=None` in `Integer.__init__`, because it's already in `Raw.__init__`.
