### PR TITLE
error_router falls back on original when it fails

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -250,6 +250,9 @@ class Api(object):
         endpoint or not. If it happened in a flask-restful endpoint, our
         handler will be dispatched. If it happened in an unrelated view, the
         app's original error handler will be dispatched.
+        In the event that the error occurred in a flask-restful endpoint but
+        the local handler can't resolve the situation, the router will fall
+        back onto the original_handler as last resort.
 
         :param original_handler: the original Flask error handler for the app
         :type original_handler: function
@@ -258,7 +261,10 @@ class Api(object):
 
         """
         if self._has_fr_route():
-            return self.handle_error(e)
+            try:
+                return self.handle_error(e)
+            except:
+                return original_handler(e)
         return original_handler(e)
 
     def handle_error(self, e):


### PR DESCRIPTION
The flask-restful library was original designed to handle all errors that
happen within the domain of its restful endpoints.

This design decision collides with the assumption other library writers make,
trusting the custom error handlers they set up in the base app to kick in when
they throw one of their custom exception.

Given that flask-restful hijacks `app.handle_exception` on initialization,
that assumption of the latter developers causes some libraries to fail.

By making the flask-restful error_router fall back onto the `original_handler`
when the local one can't handle / re-raises the exception, we return the
control to the third-party extension handler for a last attempt at handling.

This is probably the case too for the `app.handle_user_exception` hijacking,
but it wasn't investigated this time around.
