### PR TITLE
Update reqparse.py

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -148,6 +148,8 @@ class Argument(object):
                     if not isinstance(value, FileStorage):
                         if not self.case_sensitive:
                             value = value.lower()
+                            if hasattr(self.choices, "__iter__"):
+                                self.choices = [choice.lower() for choice in self.choices]
 
                         try:
                             value = self.convert(value, operator)

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -467,6 +467,15 @@ class ReqParseTestCase(unittest.TestCase):
         args = parser.parse_args(req)
         self.assertEquals('bat', args.get('foo'))
 
+        # both choices and args are case_insensitive
+        req = Request.from_values("/bubble?foo=bat")
+
+        parser = RequestParser()
+        parser.add_argument("foo", choices=["BAT"], case_sensitive=False),
+
+        args = parser.parse_args(req)
+        self.assertEquals('bat', args.get('foo'))
+
     def test_parse_ignore(self):
         req = Request.from_values("/bubble?foo=bar")
 


### PR DESCRIPTION
The current behavior is that if a user passes `?field=test` in the querystring, and the application defines choices as `choices=('TEST', 'SOMETHING')`, validation won't pass even if `case_insensitive=false`.

`case_insensitive=False` should be comparing values to case insensitive choices as well. Otherwise the choices HAVE to be in lowercase to match.
