### PR TITLE
Add resource decorator to Api class

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -355,6 +355,26 @@ class Api(object):
         else:
             self.resources.append((resource, urls, kwargs))
 
+    def resource(self, *urls, **kwargs):
+        """Wraps a :class:`~flask.ext.restful.Resource` class, adding it to the
+        api. Parameters are the same as :meth:`~flask.ext.restful.Api.add_resource`.
+
+        Example::
+
+            app = Flask(__name__)
+            api = restful.Api(app)
+
+            @api.resource('/foo')
+            class Foo(Resource):
+                def get(self):
+                    return 'Hello, World!'
+
+        """
+        def decorator(cls):
+            self.add_resource(cls, *urls, **kwargs)
+            return cls
+        return decorator
+
     def _register_view(self, app, resource, *urls, **kwargs):
         endpoint = kwargs.pop('endpoint', None) or resource.__name__.lower()
         self.endpoints.add(endpoint)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -545,6 +545,19 @@ class APITestCase(unittest.TestCase):
         app.add_url_rule.assert_called_with('/foo',
                                             view_func=api.output())
 
+    def test_resource_decorator(self):
+        app = Mock(flask.Flask)
+        app.view_functions = {}
+        api = flask_restful.Api(app)
+        api.output = Mock()
+
+        @api.resource('/foo', endpoint='bar')
+        class Foo(flask_restful.Resource):
+            pass
+
+        app.add_url_rule.assert_called_with('/foo',
+                                            view_func=api.output())
+
     def test_add_resource_kwargs(self):
         app = Mock(flask.Flask)
         app.view_functions = {}


### PR DESCRIPTION
Flask itself makes extensive use of the `@route` decorator for adding routes to the `app`. It would be helpful to be able to use this paradigm with `Resource` classes as well.

For example:

``` python
app = Flask(__name__)
api = restful.Api(app)

@api.resource('/foo')
class Foo(Resource):
    def get(self):
        return "Hello, world!!"
```
