### PR TITLE
Fixed fields.Url to allow it to be used with blueprints

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -81,8 +81,8 @@ class Raw(object):
         self.default = default
 
     def format(self, value):
-        """Formats a field's value. No-op by default - field classes that 
-        modify how the value of existing object keys should be presented should 
+        """Formats a field's value. No-op by default - field classes that
+        modify how the value of existing object keys should be presented should
         override this and apply the appropriate formatting.
 
         :param value: The value to format
@@ -98,11 +98,11 @@ class Raw(object):
 
     def output(self, key, obj):
         """Pulls the value for the given key from the object, applies the
-        field's formatting and returns the result. If the key is not found 
-        in the object, returns the default value. Field classes that create 
-        values which do not require the existence of the key in the object 
+        field's formatting and returns the result. If the key is not found
+        in the object, returns the default value. Field classes that create
+        values which do not require the existence of the key in the object
         should override this and return the desired value.
-        
+
         :exception MarshallingException: In case of formatting problem
         """
 

--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -7,7 +7,7 @@ except ImportError:
     from urllib.parse import urlparse, urlunparse
 
 from flask_restful import inputs, marshal
-from flask import url_for
+from flask import url_for, request
 
 __all__ = ["String", "FormattedString", "Url", "DateTime", "Float",
            "Integer", "Arbitrary", "Nested", "List", "Raw", "Boolean",
@@ -248,7 +248,7 @@ class Url(Raw):
     """
     A string representation of a Url
     """
-    def __init__(self, endpoint, absolute=False, scheme=None):
+    def __init__(self, endpoint=None, absolute=False, scheme=None):
         super(Url, self).__init__()
         self.endpoint = endpoint
         self.absolute = absolute
@@ -257,7 +257,8 @@ class Url(Raw):
     def output(self, key, obj):
         try:
             data = to_marshallable_type(obj)
-            o = urlparse(url_for(self.endpoint, _external=self.absolute, **data))
+            endpoint = self.endpoint if self.endpoint is not None else request.endpoint
+            o = urlparse(url_for(endpoint, _external=self.absolute, **data))
             if self.absolute:
                 scheme = self.scheme if self.scheme is not None else o.scheme
                 return urlunparse((scheme, o.netloc, o.path, "", "", ""))

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -5,7 +5,7 @@ from flask.ext.restful.fields import MarshallingException
 from flask.ext.restful.utils.ordereddict import OrderedDict
 from flask_restful import fields
 from datetime import datetime
-from flask import Flask
+from flask import Flask, Blueprint
 #noinspection PyUnresolvedReferences
 from nose.tools import assert_equals  # you need it for tests in form of continuations
 
@@ -160,6 +160,78 @@ class FieldsTestCase(unittest.TestCase):
 
         with app.test_request_context("/", base_url="http://localhost"):
             self.assertEquals("https://localhost/3", field.output("hey", Foo()))
+
+    def test_url_without_endpoint_invalid_object(self):
+        app = Flask(__name__)
+        app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
+        field = fields.Url()
+
+        with app.test_request_context("/hey"):
+            self.assertRaises(MarshallingException, lambda: field.output("hey", None))
+
+    def test_url_without_endpoint(self):
+        app = Flask(__name__)
+        app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
+        field = fields.Url()
+
+        with app.test_request_context("/hey"):
+            self.assertEquals("/3", field.output("hey", Foo()))
+
+    def test_url_without_endpoint_absolute(self):
+        app = Flask(__name__)
+        app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
+        field = fields.Url(absolute=True)
+
+        with app.test_request_context("/hey"):
+            self.assertEquals("http://localhost/3", field.output("hey", Foo()))
+
+    def test_url_without_endpoint_absolute_scheme(self):
+        app = Flask(__name__)
+        app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
+        field = fields.Url(absolute=True, scheme='https')
+
+        with app.test_request_context("/hey", base_url="http://localhost"):
+            self.assertEquals("https://localhost/3", field.output("hey", Foo()))
+
+    def test_url_with_blueprint_invalid_object(self):
+        app = Flask(__name__)
+        bp = Blueprint("foo", __name__, url_prefix="/foo")
+        bp.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
+        app.register_blueprint(bp)
+        field = fields.Url()
+
+        with app.test_request_context("/foo/hey"):
+            self.assertRaises(MarshallingException, lambda: field.output("hey", None))
+
+    def test_url_with_blueprint(self):
+        app = Flask(__name__)
+        bp = Blueprint("foo", __name__, url_prefix="/foo")
+        bp.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
+        app.register_blueprint(bp)
+        field = fields.Url()
+
+        with app.test_request_context("/foo/hey"):
+            self.assertEquals("/foo/3", field.output("hey", Foo()))
+
+    def test_url_with_blueprint_absolute(self):
+        app = Flask(__name__)
+        bp = Blueprint("foo", __name__, url_prefix="/foo")
+        bp.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
+        app.register_blueprint(bp)
+        field = fields.Url(absolute=True)
+
+        with app.test_request_context("/foo/hey"):
+            self.assertEquals("http://localhost/foo/3", field.output("hey", Foo()))
+
+    def test_url_with_blueprint_absolute_scheme(self):
+        app = Flask(__name__)
+        bp = Blueprint("foo", __name__, url_prefix="/foo")
+        bp.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
+        app.register_blueprint(bp)
+        field = fields.Url(absolute=True, scheme='https')
+
+        with app.test_request_context("/foo/hey", base_url="http://localhost"):
+            self.assertEquals("https://localhost/foo/3", field.output("hey", Foo()))
 
     def test_int(self):
         field = fields.Integer()


### PR DESCRIPTION
The `Url` field would raise an `BuildError` if you used it with a blueprint with a `url_prefix`, and didn't added this prefix on the endpoint in the `Url` constructor. Since adding the blueprint url prefix again in the `Url` constructor sort of defeats the point of having it declared on the blueprint, I made this change so, if there's no endpoint, the Url will get it from the request context. Now it can be used like this, for instance:

```
todo_fields = {
    'id': fields.Integer,
    'task': fields.String,
    'uri': fields.Url(absolute=True)
}
```

I'm not 100% sure the tests I wrote are correct, though, so, if anyone can improve/fix/tell me what's wrong, I'll be glad to fix it.