### PR TITLE
Docs example name clash

### DIFF
--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -25,7 +25,7 @@ on the :class:`~Api` object. ::
     api = restful.Api(app)
 
     @api.representation('application/json')
-    def json(data, code, headers=None):
+    def output_json(data, code, headers=None):
         resp = make_response(json.dumps(data), code)
         resp.headers.extend(headers or {})
         return resp


### PR DESCRIPTION
Content negotiation example in extending flask restful won't work out of the box. json.dumps() will throw error `AttributeError: 'function' object has no attribute 'dumps'` as we've just defined a function with the same name
