### PR TITLE
Fixed add new todo

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -264,6 +264,10 @@ Save this example in api.py ::
         def post(self):
             args = parser.parse_args()
             todo_id = 'todo%d' % (len(TODOS) + 1)
+            i = 2
+            while todo_id in TODOS:
+                todo_id = 'todo%d' % (len(TODOS) + i)
+                i = i + 1
             TODOS[todo_id] = {'task': args['task']}
             return TODOS[todo_id], 201
 


### PR DESCRIPTION
Bug : When you delete a todo2 and then add a new todo, it'll update todo3 instead of adding a new todo i.e todo4.

Now I check in a loop if the new todo id exists or not. If it does, then I increment the count not just len(TODO)+1
