### PR TITLE
Update testing.rst

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -3,15 +3,19 @@
 Running the Tests
 =================
 
-To run the Flask-RESTful test suite, you need to do two things.
+Test setup (see the Makefile if you want to do this manually): ::
 
-1. Install the extra required dependency ::
+       make test-install
 
-       pip install -e '.[paging]' --use-mirrors
+Run test suite: ::
 
-2. Run the tests ::
+       make test
 
-       python setup.py nosetests
+To run an individual test, you need to be inside the venv that ``make test-install`` created.
+Use the nosetests convention of ``nosetests <filename>:ClassName.func_name`` to run one test. ::
+
+       source ./venv/bin/activate
+       nosetests tests/test_reqparse.py:ReqParseTestCase.test_parse_choices_insensitive
 
 Alternately, push changes to your fork on Github, and Travis will run the tests
 for your branch automatically.


### PR DESCRIPTION
Motivation:
`python setup.py nosetests` requires requirements.txt be installed, the `-e '.[paging]' --use-mirrors` dependencies, and this should both be done inside a venv.
make test-install does that.

Also adding a guide for running single unit tests so that the dependencies isn't a mystery. Running `python setup.py nosetests` by itself returns errors that aren't immediately clear that nosetests needs to be pip installed (like an import error).
