### PR TITLE
Add undocumented members to api doc

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -36,6 +36,7 @@ Fields
 ------
 .. automodule:: fields
    :members:
+   :undoc-members:
 
 Inputs
 -----


### PR DESCRIPTION
I was surprised by absence of Boolean field while looking at the docs. 
