### PR TITLE
Map resource

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -380,7 +380,7 @@ class Api(object):
             api.add_resource('/special/foo', FooSpecial, endpoint="foo")
 
         """
-        self.add_resource(self, resource, url, **kwargs)
+        self.add_resource(resource, url, **kwargs)
 
     def resource(self, *urls, **kwargs):
         """Wraps a :class:`~flask.ext.restful.Resource` class, adding it to the

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -375,9 +375,9 @@ class Api(object):
 
         Examples::
 
-            api.add_resource(HelloWorld, '/', '/hello')
-            api.add_resource(Foo, '/foo', endpoint="foo")
-            api.add_resource(FooSpecial, '/special/foo', endpoint="foo")
+            api.add_resource('/', HelloWorld)
+            api.add_resource('/foo', Foo, endpoint="foo")
+            api.add_resource('/special/foo', FooSpecial, endpoint="foo")
 
         """
         if self.app is not None:

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -355,6 +355,36 @@ class Api(object):
         else:
             self.resources.append((resource, urls, kwargs))
 
+    def map_resource(self, resource, url, **kwargs):
+        """Maps an API endpoint to a resource.
+
+        :param url: the url route to match to the given resource, standard
+                     flask routing rules apply.  Any url variables will be
+                     passed to the resource method as args.
+        :type url: str
+
+        :param resource: the class name of your resource
+        :type resource: :class:`Resource`
+
+        :param endpoint: endpoint name (defaults to :meth:`Resource.__name__.lower`
+            Can be used to reference this route in :class:`fields.Url` fields
+        :type endpoint: str
+
+        Additional keyword arguments not specified above will be passed as-is
+        to :meth:`flask.Flask.add_url_rule`.
+
+        Examples::
+
+            api.add_resource(HelloWorld, '/', '/hello')
+            api.add_resource(Foo, '/foo', endpoint="foo")
+            api.add_resource(FooSpecial, '/special/foo', endpoint="foo")
+
+        """
+        if self.app is not None:
+            self._register_view(self.app, resource, url, **kwargs)
+        else:
+            self.resources.append((resource, [url], kwargs))
+
     def resource(self, *urls, **kwargs):
         """Wraps a :class:`~flask.ext.restful.Resource` class, adding it to the
         api. Parameters are the same as :meth:`~flask.ext.restful.Api.add_resource`.

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -380,10 +380,7 @@ class Api(object):
             api.add_resource('/special/foo', FooSpecial, endpoint="foo")
 
         """
-        if self.app is not None:
-            self._register_view(self.app, resource, url, **kwargs)
-        else:
-            self.resources.append((resource, [url], kwargs))
+        self.add_resource(self, resource, url, **kwargs)
 
     def resource(self, *urls, **kwargs):
         """Wraps a :class:`~flask.ext.restful.Resource` class, adding it to the

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -355,7 +355,7 @@ class Api(object):
         else:
             self.resources.append((resource, urls, kwargs))
 
-    def map_resource(self, resource, url, **kwargs):
+    def map_resource(self, url, resource, **kwargs):
         """Maps an API endpoint to a resource.
 
         :param url: the url route to match to the given resource, standard

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -375,9 +375,9 @@ class Api(object):
 
         Examples::
 
-            api.add_resource('/', HelloWorld)
-            api.add_resource('/foo', Foo, endpoint="foo")
-            api.add_resource('/special/foo', FooSpecial, endpoint="foo")
+            api.map_resource('/', HelloWorld)
+            api.map_resource('/foo', Foo, endpoint="foo")
+            api.map_resource('/special/foo', FooSpecial, endpoint="foo")
 
         """
         self.add_resource(resource, url, **kwargs)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -503,6 +503,17 @@ class APITestCase(unittest.TestCase):
 
         view.as_view.assert_called_with('bar')
 
+    def test_map_resource_endpoint(self):
+        app = Mock()
+        app.view_functions = {}
+        view = Mock()
+
+        api = flask_restful.Api(app)
+        api.output = Mock()
+        api.map_resource('/foo', view, endpoint='bar')
+
+        view.as_view.assert_called_with('bar')
+
     def test_add_two_conflicting_resources_on_same_endpoint(self):
         app = Flask(__name__)
         api = flask_restful.Api(app)


### PR DESCRIPTION
Adds a `map_resource()` function that takes the URL of an endpoint as the first arg, the resource class as the second, and passes along `**kwargs`.

Resolves #299. 