### PR TITLE
Check if the code is a proper integer before comparison

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -279,8 +279,14 @@ class Api(object):
             else:
                 raise e
 
-        code = getattr(e, 'code', 500)
-        data = getattr(e, 'data', error_data(code))
+        if isinstance(e, HTTPException):
+            code = e.code
+            data = getattr(e, 'data', error_data(code))
+
+        else:
+            code = 500
+            data = error_data(code)
+
         headers = {}
 
         if code >= 500:

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -272,7 +272,7 @@ class Api(object):
         """
         got_request_exception.send(current_app._get_current_object(), exception=e)
 
-        if not hasattr(e, 'code') and current_app.propagate_exceptions:
+        if not isinstance(e, HTTPException) and current_app.propagate_exceptions:
             exc_type, exc_value, tb = sys.exc_info()
             if exc_value is e:
                 raise

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,21 +1,30 @@
 import unittest
+
+from json import dumps, loads
+
+import flask
 from flask import Flask, redirect, views
+from flask.ext.restful.utils import http_status_message, error_data, unpack
 from flask.signals import got_request_exception, signals_available
+
 try:
     from mock import Mock, patch
 except:
     # python3
     from unittest.mock import Mock, patch
-import flask
+
+from nose.tools import assert_equals, assert_true  # you need it for tests in form of continuations
+
+#noinspection PyUnresolvedReferences
+import six
+
 import werkzeug
-from flask.ext.restful.utils import http_status_message, error_data, unpack
+from werkzeug.exceptions import HTTPException
+
 import flask_restful
 import flask_restful.fields
 from flask_restful import OrderedDict
-from json import dumps, loads
-#noinspection PyUnresolvedReferences
-from nose.tools import assert_equals, assert_true  # you need it for tests in form of continuations
-import six
+
 
 
 def check_unpack(expected, value):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -74,7 +74,7 @@ class APITestCase(unittest.TestCase):
     def test_handle_error_401_sends_challege_default_realm(self):
         app = Flask(__name__)
         api = flask_restful.Api(app)
-        exception = Mock()
+        exception = Mock(spec=HTTPException)
         exception.code = 401
         exception.data = {'foo': 'bar'}
 
@@ -88,7 +88,7 @@ class APITestCase(unittest.TestCase):
         app = Flask(__name__)
         app.config['HTTP_BASIC_AUTH_REALM'] = 'test-realm'
         api = flask_restful.Api(app)
-        exception = Mock()
+        exception = Mock(spec=HTTPException)
         exception.code = 401
         exception.data = {'foo': 'bar'}
 
@@ -342,7 +342,7 @@ class APITestCase(unittest.TestCase):
         app = Flask(__name__)
         api = flask_restful.Api(app)
 
-        exception = Mock()
+        exception = Mock(spec=HTTPException)
         exception.code = 500
         exception.data = {'foo': 'bar'}
 
@@ -353,11 +353,24 @@ class APITestCase(unittest.TestCase):
                 'foo': 'bar',
             }))
 
-    def test_handle_auth(self):
+    def test_handle_error_with_code(self):
         app = Flask(__name__)
         api = flask_restful.Api(app)
 
         exception = Mock()
+        exception.code = "JSONResponseError"
+        exception.data = {'foo': 'bar'}
+
+        with app.test_request_context("/foo"):
+            resp = api.handle_error(exception)
+            self.assertEquals(resp.status_code, 500)
+            self.assertEquals(resp.data.decode(), dumps({"status": 500, "message": "Internal Server Error"}))
+
+    def test_handle_auth(self):
+        app = Flask(__name__)
+        api = flask_restful.Api(app)
+
+        exception = Mock(spec=HTTPException)
         exception.code = 401
         exception.data = {'foo': 'bar'}
 
@@ -411,7 +424,7 @@ class APITestCase(unittest.TestCase):
         app = Flask(__name__)
         api = flask_restful.Api(app)
 
-        exception = Mock()
+        exception = Mock(spec=HTTPException)
         exception.code = 400
         exception.data = {'foo': 'bar'}
 
@@ -433,7 +446,7 @@ class APITestCase(unittest.TestCase):
         app = Flask(__name__)
         api = flask_restful.Api(app)
 
-        exception = Mock()
+        exception = Mock(spec=HTTPException)
         exception.code = 400
         exception.data = {'foo': 'bar'}
 
@@ -449,7 +462,7 @@ class APITestCase(unittest.TestCase):
         api = flask_restful.Api(app)
         view = flask_restful.Resource
 
-        exception = Mock()
+        exception = Mock(spec=HTTPException)
         exception.code = 404
         exception.data = {"status": 404, "message": "Not Found"}
         api.add_resource(view, '/foo', endpoint='bor')
@@ -497,7 +510,7 @@ class APITestCase(unittest.TestCase):
         app.handle_exception = Mock()
         api.handle_error = Mock(side_effect=Exception())
         api._has_fr_route = Mock(return_value=True)
-        exception = Mock()
+        exception = Mock(spec=HTTPException)
 
         with app.test_request_context('/foo'):
             api.error_router(exception, app.handle_exception)


### PR DESCRIPTION
Boto's [JSONReponseError](http://boto.readthedocs.org/en/latest/ref/boto.html#boto.exception.JSONResponseError) provides an attribute `code`, which makes Flask Restful break in the event that is the exception. This adds some very basic type checking to make sure that the real error isn't hidden.
```
Traceback (most recent call last):
  File "/Users/newmaniese/VirtualEnvs/bobcat2/lib/python3.4/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/Users/newmaniese/VirtualEnvs/bobcat2/lib/python3.4/site-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/Users/newmaniese/VirtualEnvs/bobcat2/src/flaskrestful/flask_restful/__init__.py", line 261, in error_router
    return self.handle_error(e)
  File "/Users/newmaniese/VirtualEnvs/bobcat2/lib/python3.4/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/newmaniese/VirtualEnvs/bobcat2/lib/python3.4/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/newmaniese/VirtualEnvs/bobcat2/src/flaskrestful/flask_restful/__init__.py", line 261, in error_router
    return self.handle_error(e)
  File "/Users/newmaniese/VirtualEnvs/bobcat2/src/flaskrestful/flask_restful/__init__.py", line 284, in handle_error
    if code >= 500:
TypeError: unorderable types: str() >= int()
```
