### PR TITLE
Fixed add new todo

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -264,10 +264,8 @@ Save this example in api.py ::
 
         def post(self):
             args = parser.parse_args()
-            r = re.compile("([a-zA-Z]+)([0-9]+)")
-            m = r.match(max(TODOS.keys()))
-            temp_id = int(m.group(2)) + 1
-            todo_id = m.group(1) + str(temp_id)
+            temp_id = int(max(TODOS.keys()).lstrip('todo')) + 1
+            todo_id = 'todo' + str(temp_id) 
             TODOS[todo_id] = {'task': args['task']}
             return TODOS[todo_id], 201
 


### PR DESCRIPTION
Bug : When you delete a todo2 and then add a new todo, it'll update todo3 instead of adding a new todo i.e todo4. 

This one will create a todo_id without any loop(my last fix was with loop).
