### PR TITLE
Allow specifying a default serialization value if marshaled object is None

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -33,7 +33,7 @@ is supported as well) ::
     }
     
     class Todo(Resource):
-        @marshal_with(resource_fields, envelope='resource')
+        @marshal_with(resource_fields, default={}, envelope='resource')
         def get(self, **kwargs):
             return db_get_todo()  # Some function that queries the db
 
@@ -42,7 +42,9 @@ This example assumes that you have a custom database object (``todo``) that
 has attributes ``name``, ``address``, and ``date_updated``.  Any additional
 attributes on the object are considered private and won't be rendered in the
 output. An optional ``envelope`` keyword argument is specified to wrap the
-resulting output.
+resulting output. ``default`` keyword argument allows specifying the value that
+the data will serialized into if the data in None (by default it is the dictionary
+with all null keys).
 
 The decorator ``marshal_with`` is what actually takes your data object and applies the
 field filtering.  The marshalling can work on single objects, dicts, or

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -535,13 +535,15 @@ class Resource(MethodView):
         return resp
 
 
-def marshal(data, fields, envelope=None):
+def marshal(data, fields, default='all_null', envelope=None):
     """Takes raw data (in the form of a dict, list, object) and a dict of
     fields to output and filters the data based on those fields.
 
     :param data: the actual object(s) from which the fields are taken from
     :param fields: a dict of whose keys will make up the final serialized
                    response output
+    :param default: value that the data will serialized into if the data in None.
+                    By default the value is a dictionary with all null keys
     :param envelope: optional key that will be used to envelop the serialized
                      response
 
@@ -557,6 +559,8 @@ def marshal(data, fields, envelope=None):
     OrderedDict([('data', OrderedDict([('a', 100)]))])
 
     """
+    if data is None and default != 'all_null':
+        return {envelope: default} if envelope else default
 
     def make(cls):
         if isinstance(cls, type):
@@ -564,10 +568,10 @@ def marshal(data, fields, envelope=None):
         return cls
 
     if isinstance(data, (list, tuple)):
-        return (OrderedDict([(envelope, [marshal(d, fields) for d in data])])
-                if envelope else [marshal(d, fields) for d in data])
+        return (OrderedDict([(envelope, [marshal(d, fields, default=default) for d in data])])
+                if envelope else [marshal(d, fields, default=default) for d in data])
 
-    items = ((k, marshal(data, v) if isinstance(v, dict)
+    items = ((k, marshal(data, v, default=default) if isinstance(v, dict)
               else make(v).output(k, data))
              for k, v in fields.items())
     return OrderedDict([(envelope, OrderedDict(items))]) if envelope else OrderedDict(items)
@@ -596,14 +600,17 @@ class marshal_with(object):
 
     see :meth:`flask.ext.restful.marshal`
     """
-    def __init__(self, fields, envelope=None):
+    def __init__(self, fields, default='all_null', envelope=None):
         """
         :param fields: a dict of whose keys will make up the final
                        serialized response output
+        :param default: value that the data will serialized into if the data in None.
+                        By default the value is a dictionary with all null keys
         :param envelope: optional key that will be used to envelop the serialized
                          response
         """
         self.fields = fields
+        self.default = default
         self.envelope = envelope
 
     def __call__(self, f):
@@ -612,9 +619,9 @@ class marshal_with(object):
             resp = f(*args, **kwargs)
             if isinstance(resp, tuple):
                 data, code, headers = unpack(resp)
-                return marshal(data, self.fields, self.envelope), code, headers
+                return marshal(data, self.fields, self.default, self.envelope), code, headers
             else:
-                return marshal(resp, self.fields, self.envelope)
+                return marshal(resp, self.fields, self.default, self.envelope)
         return wrapper
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -101,11 +101,29 @@ class APITestCase(unittest.TestCase):
         output = flask_restful.marshal(marshal_dict, fields)
         self.assertEquals(output, {'foo': 'bar'})
 
+    def test_marshal_with_default(self):
+        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
+        marshal_obj = None
+        output = flask_restful.marshal(marshal_obj, fields, default={})
+        self.assertEquals(output, {})
+
+    def test_marshal_with_default_none(self):
+        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
+        marshal_obj = None
+        output = flask_restful.marshal(marshal_obj, fields, default=None)
+        self.assertEquals(output, None)
+
     def test_marshal_with_envelope(self):
         fields = OrderedDict([('foo', flask_restful.fields.Raw)])
         marshal_dict = OrderedDict([('foo', 'bar'), ('bat', 'baz')])
         output = flask_restful.marshal(marshal_dict, fields, envelope='hey')
         self.assertEquals(output, {'hey': {'foo': 'bar'}})
+
+    def test_marshal_with_default_and_envelope(self):
+        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
+        marshal_obj = None
+        output = flask_restful.marshal(marshal_obj, fields, default={}, envelope='hey')
+        self.assertEquals(output, {'hey': {}})
 
     def test_marshal_decorator(self):
         fields = OrderedDict([('foo', flask_restful.fields.Raw)])
@@ -114,6 +132,22 @@ class APITestCase(unittest.TestCase):
         def try_me():
             return OrderedDict([('foo', 'bar'), ('bat', 'baz')])
         self.assertEquals(try_me(), {'foo': 'bar'})
+
+    def test_marshal_decorator_with_default(self):
+        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
+
+        @flask_restful.marshal_with(fields, default={})
+        def try_me():
+            return None
+        self.assertEquals(try_me(), {})
+
+    def test_marshal_decorator_with_default_none(self):
+        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
+
+        @flask_restful.marshal_with(fields, default=None)
+        def try_me():
+            return None
+        self.assertEquals(try_me(), None)
 
     def test_marshal_decorator_with_envelope(self):
         fields = OrderedDict([('foo', flask_restful.fields.Raw)])
@@ -124,6 +158,15 @@ class APITestCase(unittest.TestCase):
 
         self.assertEquals(try_me(), {'hey': {'foo': 'bar'}})
 
+    def test_marshal_decorator_with_default_and_envelope(self):
+        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
+
+        @flask_restful.marshal_with(fields, default={}, envelope='hey')
+        def try_me():
+            return None
+
+        self.assertEquals(try_me(), {'hey': {}})
+
     def test_marshal_decorator_tuple(self):
         fields = OrderedDict([('foo', flask_restful.fields.Raw)])
 
@@ -131,6 +174,22 @@ class APITestCase(unittest.TestCase):
         def try_me():
             return OrderedDict([('foo', 'bar'), ('bat', 'baz')]), 200, {'X-test': 123}
         self.assertEquals(try_me(), ({'foo': 'bar'}, 200, {'X-test': 123}))
+
+    def test_marshal_decorator_tuple_with_default(self):
+        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
+
+        @flask_restful.marshal_with(fields, default={})
+        def try_me():
+            return None, 200, {'X-test': 123}
+        self.assertEquals(try_me(), ({}, 200, {'X-test': 123}))
+
+    def test_marshal_decorator_tuple_with_default_none(self):
+        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
+
+        @flask_restful.marshal_with(fields, default=None)
+        def try_me():
+            return None, 200, {'X-test': 123}
+        self.assertEquals(try_me(), (None, 200, {'X-test': 123}))
 
     def test_marshal_decorator_tuple_with_envelope(self):
         fields = OrderedDict([('foo', flask_restful.fields.Raw)])
@@ -140,6 +199,15 @@ class APITestCase(unittest.TestCase):
             return OrderedDict([('foo', 'bar'), ('bat', 'baz')]), 200, {'X-test': 123}
 
         self.assertEquals(try_me(), ({'hey': {'foo': 'bar'}}, 200, {'X-test': 123}))
+
+    def test_marshal_decorator_tuple_with_default_and_envelope(self):
+        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
+
+        @flask_restful.marshal_with(fields, default={}, envelope='hey')
+        def try_me():
+            return None, 200, {'X-test': 123}
+
+        self.assertEquals(try_me(), ({'hey': {}}, 200, {'X-test': 123}))
 
     def test_marshal_field_decorator(self):
         field = flask_restful.fields.Raw
@@ -169,11 +237,23 @@ class APITestCase(unittest.TestCase):
         output = flask_restful.marshal((marshal_fields,), fields)
         self.assertEquals(output, [{'foo': 'bar'}])
 
+    def test_marshal_tuple_with_default(self):
+        fields = OrderedDict({'foo': flask_restful.fields.Raw})
+        marshal_obj = None
+        output = flask_restful.marshal((marshal_obj,), fields, default={})
+        self.assertEquals(output, [{}])
+
     def test_marshal_tuple_with_envelope(self):
         fields = OrderedDict({'foo': flask_restful.fields.Raw})
         marshal_fields = OrderedDict([('foo', 'bar'), ('bat', 'baz')])
         output = flask_restful.marshal((marshal_fields,), fields, envelope='hey')
         self.assertEquals(output, {'hey': [{'foo': 'bar'}]})
+
+    def test_marshal_tuple_with_default_and_envelope(self):
+        fields = OrderedDict({'foo': flask_restful.fields.Raw})
+        marshal_obj = None
+        output = flask_restful.marshal((marshal_obj,), fields, default={}, envelope='hey')
+        self.assertEquals(output, {'hey': [{}]})
 
     def test_marshal_nested(self):
         fields = OrderedDict([


### PR DESCRIPTION
I'm not 100% sure this feature is at all needed but I came across a situation when I needed to return an empty object instead of the dictionary with all null keys for a marshaled object.
My example is the following:
```python
@marshal_with(IMDB_DATA, default={}, envelope='imdb_data')
def get(self, movie_id):
    movie = Movie.query.get(movie_id)
    return movie.imdb_data
```
`Movie.imdb_data` is an SQLAlchemy one-to-one relationship. When I query `/movies/1083/imdb-data` and the movie does not have IMDB data associated I'd rather return an empty JSON object than the object with all null keys.

Basically the behavior is the same as `default` kwarg for `flask_restful.fileds` classes.