### PR TITLE
Fix BadRequest raised with empty body and application/json content type

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -250,7 +250,7 @@ class RequestParser(object):
 
         # A record of arguments not yet parsed; as each is found
         # among self.args, it will be popped out
-        req.unparsed_arguments = dict(Argument('').source(req))
+        req.unparsed_arguments = dict(Argument('').source(req)) if strict else {}
 
         for arg in self.args:
             value, found = arg.parse(req)

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -653,6 +653,16 @@ class ReqParseTestCase(unittest.TestCase):
             self.assertEquals(args['foo'], 1)
             self.assertEquals(args['baz'], 2)
 
+    def test_not_json_location_and_content_type_json(self):
+        app = Flask(__name__)
+
+        parser = RequestParser()
+        parser.add_argument('foo', location='args')
+
+        with app.test_request_context('/bubble', method='get',
+                                      content_type='application/json'):
+            parser.parse_args() # Should not raise a 400: BadRequest
+
     def test_request_parser_remove_argument(self):
         req = Request.from_values("/bubble?foo=baz")
         parser = RequestParser()


### PR DESCRIPTION
A ReqParser behavior change was introduced in 49502376 as a  side-effect.

Before 49502376, `ReqParser` was able to handle request with empty body and `content_type='application/json'` if none of the arguments where expected in the JSON.
After 49502376, `ReqParser` raise a BadRequest try to read `request.json`, even if none of the argument has `location='json'`, even with `strict=False`

This pull-request restore this behavior when `strict=False`
