### PR TITLE
Fix truncation of microseconds in iso8601 date inputs

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -1,4 +1,8 @@
+from datetime import datetime
+from calendar import timegm
+import pytz
 from decimal import Decimal as MyDecimal, ROUND_HALF_EVEN
+from email.utils import formatdate
 import six
 try:
     from urlparse import urlparse, urlunparse
@@ -6,7 +10,7 @@ except ImportError:
     # python3
     from urllib.parse import urlparse, urlunparse
 
-from flask_restful import inputs, marshal
+from flask_restful import marshal
 from flask import url_for
 
 __all__ = ["String", "FormattedString", "Url", "DateTime", "Float",
@@ -81,8 +85,8 @@ class Raw(object):
         self.default = default
 
     def format(self, value):
-        """Formats a field's value. No-op by default - field classes that 
-        modify how the value of existing object keys should be presented should 
+        """Formats a field's value. No-op by default - field classes that
+        modify how the value of existing object keys should be presented should
         override this and apply the appropriate formatting.
 
         :param value: The value to format
@@ -98,11 +102,11 @@ class Raw(object):
 
     def output(self, key, obj):
         """Pulls the value for the given key from the object, applies the
-        field's formatting and returns the result. If the key is not found 
-        in the object, returns the default value. Field classes that create 
-        values which do not require the existence of the key in the object 
+        field's formatting and returns the result. If the key is not found
+        in the object, returns the default value. Field classes that create
+        values which do not require the existence of the key in the object
         should override this and return the desired value.
-        
+
         :exception MarshallingException: In case of formatting problem
         """
 
@@ -320,7 +324,8 @@ class DateTime(Raw):
     Return a formatted datetime string in UTC. Supported formats are RFC 822
     and ISO 8601.
 
-    :param: str dt_format: rfc822 or iso8601
+    :param dt_format: ``'rfc822'`` or ``'iso8601'``
+    :type dt_format: str
     """
     def __init__(self, dt_format='rfc822', **kwargs):
         super(DateTime, self).__init__(**kwargs)
@@ -329,9 +334,9 @@ class DateTime(Raw):
     def format(self, value):
         try:
             if self.dt_format == 'rfc822':
-                return inputs.rfc822(value)
+                return _rfc822(value)
             elif self.dt_format == 'iso8601':
-                return inputs.iso8601(value)
+                return _iso8601(value)
             else:
                 raise MarshallingException(
                     'Unsupported date format %s' % self.dt_format
@@ -359,3 +364,33 @@ class Fixed(Raw):
 
 """Alias for :py:class:`~fields.Fixed`"""
 Price = Fixed
+
+
+def _rfc822(dt):
+    """Turn a datetime object into a formatted date.
+
+    Example::
+
+        fields._rfc822(datetime(2011, 1, 1)) => "Sat, 01 Jan 2011 00:00:00 -0000"
+
+    :param dt: The datetime to transform
+    :type dt: datetime
+    :return: A RFC 822 formatted date string
+    """
+    return formatdate(timegm(dt.utctimetuple()))
+
+
+def _iso8601(dt):
+    """Turn a datetime object into an ISO8601 formatted date.
+
+    Example::
+
+        fields._iso8601(datetime(2012, 1, 1, 0, 0)) => "2012-01-01T00:00:00+00:00"
+
+    :param dt: The datetime to transform
+    :type dt: datetime
+    :return: A ISO 8601 formatted date string
+    """
+    return datetime.isoformat(
+        datetime.fromtimestamp(timegm(dt.utctimetuple()), tz=pytz.UTC)
+    )

--- a/flask_restful/inputs.py
+++ b/flask_restful/inputs.py
@@ -1,6 +1,6 @@
 from calendar import timegm
 from datetime import datetime, time, timedelta
-from email.utils import formatdate, parsedate_tz, mktime_tz
+from email.utils import parsedate_tz, mktime_tz
 import re
 
 import aniso8601
@@ -215,36 +215,6 @@ def boolean(value):
     if value in ('false', '0',):
         return False
     raise ValueError("Invalid literal for boolean(): {}".format(value))
-
-
-def rfc822(dt):
-    """Turn a datetime object into a formatted date.
-
-    Example::
-
-        inputs.rfc822(datetime(2011, 1, 1)) => "Sat, 01 Jan 2011 00:00:00 -0000"
-
-    :param dt: The datetime to transform
-    :type dt: datetime
-    :return: A RFC 822 formatted date string
-    """
-    return formatdate(timegm(dt.utctimetuple()))
-
-
-def iso8601(dt):
-    """Turn a datetime object into an ISO8601 formatted date.
-
-    Example::
-
-        inputs.iso8601(datetime(2012, 1, 1, 0, 0)) => "2012-01-01T00:00:00+00:00"
-
-    :param dt: The datetime to transform
-    :type dt: datetime
-    :return: A ISO 8601 formatted date string
-    """
-    return datetime.isoformat(
-        datetime.fromtimestamp(timegm(dt.utctimetuple()), tz=pytz.UTC)
-    )
 
 
 def datetime_from_rfc822(datetime_str):

--- a/flask_restful/inputs.py
+++ b/flask_restful/inputs.py
@@ -242,6 +242,4 @@ def datetime_from_iso8601(datetime_str):
     :type datetime_str: str
     :return: A datetime
     """
-    return datetime.fromtimestamp(
-        timegm(aniso8601.parse_datetime(datetime_str).utctimetuple()), tz=pytz.UTC
-    )
+    return aniso8601.parse_datetime(datetime_str)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+import pytz
 import unittest
 from mock import Mock
 from flask.ext.restful.fields import MarshallingException
@@ -49,6 +50,34 @@ def test_boolean():
     ]
     for value, expected in values:
         yield check_field, expected, fields.Boolean(), value
+
+
+def test_rfc822_datetime_formatters():
+    dates = [
+        (datetime(2011, 1, 1), "Sat, 01 Jan 2011 00:00:00 -0000"),
+        (datetime(2011, 1, 1, 23, 59, 59),
+         "Sat, 01 Jan 2011 23:59:59 -0000"),
+        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.utc),
+         "Sat, 01 Jan 2011 23:59:59 -0000"),
+        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.timezone('CET')),
+         "Sat, 01 Jan 2011 22:59:59 -0000")
+    ]
+    for date_obj, expected in dates:
+        yield assert_equals, fields._rfc822(date_obj), expected
+
+
+def test_iso8601_datetime_formatters():
+    dates = [
+        (datetime(2011, 1, 1), "2011-01-01T00:00:00+00:00"),
+        (datetime(2011, 1, 1, 23, 59, 59),
+         "2011-01-01T23:59:59+00:00"),
+        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.utc),
+         "2011-01-01T23:59:59+00:00"),
+        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.timezone('CET')),
+         "2011-01-01T22:59:59+00:00")
+    ]
+    for date_obj, expected in dates:
+        yield assert_equals, fields._iso8601(date_obj), expected
 
 
 class FieldsTestCase(unittest.TestCase):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -21,11 +21,6 @@ class Bar(object):
         return {"hey": 3}
 
 
-class TZ(tzinfo):
-    def utcoffset(self, dt):
-        return timedelta(hours=2)
-
-
 def check_field(expected, field, value):
     assert_equals(expected, field.output('a', {'a': value}))
 
@@ -271,9 +266,9 @@ class FieldsTestCase(unittest.TestCase):
         self.assertEquals("Mon, 22 Aug 2011 20:58:45 -0000", field.output("bar", obj))
 
     def test_rfc822_date_field_with_offset(self):
-        obj = {"bar": datetime(2011, 8, 22, 20, 58, 45, tzinfo=TZ())}
+        obj = {"bar": datetime(2011, 8, 22, 20, 58, 45, tzinfo=pytz.timezone('CET'))}
         field = fields.DateTime()
-        self.assertEquals("Mon, 22 Aug 2011 18:58:45 -0000", field.output("bar", obj))
+        self.assertEquals("Mon, 22 Aug 2011 19:58:45 -0000", field.output("bar", obj))
 
     def test_iso8601_date_field_without_offset(self):
         obj = {"bar": datetime(2011, 8, 22, 20, 58, 45)}
@@ -281,9 +276,9 @@ class FieldsTestCase(unittest.TestCase):
         self.assertEquals("2011-08-22T20:58:45+00:00", field.output("bar", obj))
 
     def test_iso8601_date_field_with_offset(self):
-        obj = {"bar": datetime(2011, 8, 22, 20, 58, 45, tzinfo=TZ())}
+        obj = {"bar": datetime(2011, 8, 22, 20, 58, 45, tzinfo=pytz.timezone('CET'))}
         field = fields.DateTime(dt_format='iso8601')
-        self.assertEquals("2011-08-22T18:58:45+00:00", field.output("bar", obj))
+        self.assertEquals("2011-08-22T19:58:45+00:00", field.output("bar", obj))
 
     def test_unsupported_datetime_format(self):
         obj = {"bar": datetime(2011, 8, 22, 20, 58, 45)}

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, tzinfo
 import unittest
+import pytz
 
 #noinspection PyUnresolvedReferences
 from nose.tools import assert_equal, assert_raises  # you need it for tests in form of continuations
@@ -7,45 +8,15 @@ import six
 
 from flask_restful import inputs
 
-# http://docs.python.org/library/datetime.html?highlight=datetime#datetime.tzinfo.fromutc
-ZERO = timedelta(0)
-HOUR = timedelta(hours=1)
-
-
-class UTC(tzinfo):
-    """UTC"""
-
-    def utcoffset(self, dt):
-        return ZERO
-
-    def tzname(self, dt):
-        return "UTC"
-
-    def dst(self, dt):
-        return ZERO
-
-
-class CET(tzinfo):
-    """CET"""
-
-    def utcoffset(self, dt):
-        return HOUR
-
-    def tzname(self, dt):
-        return "CET"
-
-    def dst(self, dt):
-        return ZERO
-
 
 def test_rfc822_datetime_formatters():
     dates = [
         (datetime(2011, 1, 1), "Sat, 01 Jan 2011 00:00:00 -0000"),
         (datetime(2011, 1, 1, 23, 59, 59),
          "Sat, 01 Jan 2011 23:59:59 -0000"),
-        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=UTC()),
+        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.utc),
          "Sat, 01 Jan 2011 23:59:59 -0000"),
-        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=CET()),
+        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.timezone('CET')),
          "Sat, 01 Jan 2011 22:59:59 -0000")
     ]
     for date_obj, expected in dates:
@@ -57,9 +28,9 @@ def test_iso8601_datetime_formatters():
         (datetime(2011, 1, 1), "2011-01-01T00:00:00+00:00"),
         (datetime(2011, 1, 1, 23, 59, 59),
          "2011-01-01T23:59:59+00:00"),
-        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=UTC()),
+        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.utc),
          "2011-01-01T23:59:59+00:00"),
-        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=CET()),
+        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.timezone('CET')),
          "2011-01-01T22:59:59+00:00")
     ]
     for date_obj, expected in dates:
@@ -68,9 +39,9 @@ def test_iso8601_datetime_formatters():
 
 def test_reverse_rfc822_datetime():
     dates = [
-        ("Sat, 01 Jan 2011 00:00:00 -0000", datetime(2011, 1, 1, tzinfo=UTC())),
-        ("Sat, 01 Jan 2011 23:59:59 -0000", datetime(2011, 1, 1, 23, 59, 59, tzinfo=UTC())),
-        ("Sat, 01 Jan 2011 21:59:59 -0200", datetime(2011, 1, 1, 23, 59, 59, tzinfo=UTC())),
+        ("Sat, 01 Jan 2011 00:00:00 -0000", datetime(2011, 1, 1, tzinfo=pytz.utc)),
+        ("Sat, 01 Jan 2011 23:59:59 -0000", datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.utc)),
+        ("Sat, 01 Jan 2011 21:59:59 -0200", datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.utc)),
     ]
 
     for date_string, expected in dates:
@@ -79,9 +50,9 @@ def test_reverse_rfc822_datetime():
 
 def test_reverse_iso8601_datetime():
     dates = [
-        ("2011-01-01T00:00:00+00:00", datetime(2011, 1, 1, tzinfo=UTC())),
-        ("2011-01-01T23:59:59+00:00", datetime(2011, 1, 1, 23, 59, 59, tzinfo=UTC())),
-        ("2011-01-01T23:59:59+02:00", datetime(2011, 1, 1, 21, 59, 59, tzinfo=UTC())),
+        ("2011-01-01T00:00:00+00:00", datetime(2011, 1, 1, tzinfo=pytz.utc)),
+        ("2011-01-01T23:59:59+00:00", datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.utc)),
+        ("2011-01-01T23:59:59+02:00", datetime(2011, 1, 1, 21, 59, 59, tzinfo=pytz.utc))
     ]
 
     for date_string, expected in dates:
@@ -242,64 +213,64 @@ def test_isointerval():
             # Full precision with explicit UTC.
             "2013-01-01T12:30:00Z/P1Y2M3DT4H5M6S",
             (
-                datetime(2013, 1, 1, 12, 30, 0, tzinfo=UTC()),
-                datetime(2014, 3, 5, 16, 35, 6, tzinfo=UTC()),
+                datetime(2013, 1, 1, 12, 30, 0, tzinfo=pytz.utc),
+                datetime(2014, 3, 5, 16, 35, 6, tzinfo=pytz.utc),
             ),
         ),
         (
             # Full precision with alternate UTC indication
             "2013-01-01T12:30+00:00/P2D",
             (
-                datetime(2013, 1, 1, 12, 30, 0, tzinfo=UTC()),
-                datetime(2013, 1, 3, 12, 30, 0, tzinfo=UTC()),
+                datetime(2013, 1, 1, 12, 30, 0, tzinfo=pytz.utc),
+                datetime(2013, 1, 3, 12, 30, 0, tzinfo=pytz.utc),
             ),
         ),
         (
             # Implicit UTC with time
             "2013-01-01T15:00/P1M",
             (
-                datetime(2013, 1, 1, 15, 0, 0, tzinfo=UTC()),
-                datetime(2013, 1, 31, 15, 0, 0, tzinfo=UTC()),
+                datetime(2013, 1, 1, 15, 0, 0, tzinfo=pytz.utc),
+                datetime(2013, 1, 31, 15, 0, 0, tzinfo=pytz.utc),
             ),
         ),
         (
             # TZ conversion
             "2013-01-01T17:00-05:00/P2W",
             (
-                datetime(2013, 1, 1, 22, 0, 0, tzinfo=UTC()),
-                datetime(2013, 1, 15, 22, 0, 0, tzinfo=UTC()),
+                datetime(2013, 1, 1, 22, 0, 0, tzinfo=pytz.utc),
+                datetime(2013, 1, 15, 22, 0, 0, tzinfo=pytz.utc),
             ),
         ),
         (
             # Date upgrade to midnight-midnight period
             "2013-01-01/P3D",
             (
-                datetime(2013, 1, 1, 0, 0, 0, tzinfo=UTC()),
-                datetime(2013, 1, 4, 0, 0, 0, 0, tzinfo=UTC()),
+                datetime(2013, 1, 1, 0, 0, 0, tzinfo=pytz.utc),
+                datetime(2013, 1, 4, 0, 0, 0, 0, tzinfo=pytz.utc),
             ),
         ),
         (
             # Start/end with UTC
             "2013-01-01T12:00:00Z/2013-02-01T12:00:00Z",
             (
-                datetime(2013, 1, 1, 12, 0, 0, tzinfo=UTC()),
-                datetime(2013, 2, 1, 12, 0, 0, tzinfo=UTC()),
+                datetime(2013, 1, 1, 12, 0, 0, tzinfo=pytz.utc),
+                datetime(2013, 2, 1, 12, 0, 0, tzinfo=pytz.utc),
             ),
         ),
         (
             # Start/end with time upgrade
             "2013-01-01/2013-06-30",
             (
-                datetime(2013, 1, 1, tzinfo=UTC()),
-                datetime(2013, 6, 30, tzinfo=UTC()),
+                datetime(2013, 1, 1, tzinfo=pytz.utc),
+                datetime(2013, 6, 30, tzinfo=pytz.utc),
             ),
         ),
         (
             # Start/end with TZ conversion
             "2013-02-17T12:00:00-07:00/2013-02-28T15:00:00-07:00",
             (
-                datetime(2013, 2, 17, 19, 0, 0, tzinfo=UTC()),
-                datetime(2013, 2, 28, 22, 0, 0, tzinfo=UTC()),
+                datetime(2013, 2, 17, 19, 0, 0, tzinfo=pytz.utc),
+                datetime(2013, 2, 28, 22, 0, 0, tzinfo=pytz.utc),
             ),
         ),
         # Resolution expansion for single date(time)
@@ -307,72 +278,72 @@ def test_isointerval():
             # Second with UTC
             "2013-01-01T12:30:45Z",
             (
-                datetime(2013, 1, 1, 12, 30, 45, tzinfo=UTC()),
-                datetime(2013, 1, 1, 12, 30, 46, tzinfo=UTC()),
+                datetime(2013, 1, 1, 12, 30, 45, tzinfo=pytz.utc),
+                datetime(2013, 1, 1, 12, 30, 46, tzinfo=pytz.utc),
             ),
         ),
         (
             # Second with tz conversion
             "2013-01-01T12:30:45+02:00",
             (
-                datetime(2013, 1, 1, 10, 30, 45, tzinfo=UTC()),
-                datetime(2013, 1, 1, 10, 30, 46, tzinfo=UTC()),
+                datetime(2013, 1, 1, 10, 30, 45, tzinfo=pytz.utc),
+                datetime(2013, 1, 1, 10, 30, 46, tzinfo=pytz.utc),
             ),
         ),
         (
             # Second with implicit UTC
             "2013-01-01T12:30:45",
             (
-                datetime(2013, 1, 1, 12, 30, 45, tzinfo=UTC()),
-                datetime(2013, 1, 1, 12, 30, 46, tzinfo=UTC()),
+                datetime(2013, 1, 1, 12, 30, 45, tzinfo=pytz.utc),
+                datetime(2013, 1, 1, 12, 30, 46, tzinfo=pytz.utc),
             ),
         ),
         (
             # Minute with UTC
             "2013-01-01T12:30+00:00",
             (
-                datetime(2013, 1, 1, 12, 30, tzinfo=UTC()),
-                datetime(2013, 1, 1, 12, 31, tzinfo=UTC()),
+                datetime(2013, 1, 1, 12, 30, tzinfo=pytz.utc),
+                datetime(2013, 1, 1, 12, 31, tzinfo=pytz.utc),
             ),
         ),
         (
             # Minute with conversion
             "2013-01-01T12:30+04:00",
             (
-                datetime(2013, 1, 1, 8, 30, tzinfo=UTC()),
-                datetime(2013, 1, 1, 8, 31, tzinfo=UTC()),
+                datetime(2013, 1, 1, 8, 30, tzinfo=pytz.utc),
+                datetime(2013, 1, 1, 8, 31, tzinfo=pytz.utc),
             ),
         ),
         (
             # Minute with implicit UTC
             "2013-01-01T12:30",
             (
-                datetime(2013, 1, 1, 12, 30, tzinfo=UTC()),
-                datetime(2013, 1, 1, 12, 31, tzinfo=UTC()),
+                datetime(2013, 1, 1, 12, 30, tzinfo=pytz.utc),
+                datetime(2013, 1, 1, 12, 31, tzinfo=pytz.utc),
             ),
         ),
         (
             # Hour, explicit UTC
             "2013-01-01T12Z",
             (
-                datetime(2013, 1, 1, 12, tzinfo=UTC()),
-                datetime(2013, 1, 1, 13, tzinfo=UTC()),
+                datetime(2013, 1, 1, 12, tzinfo=pytz.utc),
+                datetime(2013, 1, 1, 13, tzinfo=pytz.utc),
             ),
         ),
         (
             # Hour with offset
             "2013-01-01T12-07:00",
             (
-                datetime(2013, 1, 1, 19, tzinfo=UTC()),
-                datetime(2013, 1, 1, 20, tzinfo=UTC()),
+                datetime(2013, 1, 1, 19, tzinfo=pytz.utc),
+                datetime(2013, 1, 1, 20, tzinfo=pytz.utc),
             ),
         ),
         (
             # Hour with implicit UTC
             "2013-01-01T12",
             (
-                datetime(2013, 1, 1, 12, tzinfo=UTC()),
-                datetime(2013, 1, 1, 13, tzinfo=UTC()),
+                datetime(2013, 1, 1, 12, tzinfo=pytz.utc),
+                datetime(2013, 1, 1, 13, tzinfo=pytz.utc),
             ),
         ),
         (
@@ -380,8 +351,8 @@ def test_isointerval():
             # be accepted.
             "2013-01-01T12:00:00.0/2013-01-01T12:30:00.000000",
             (
-                datetime(2013, 1, 1, 12, tzinfo=UTC()),
-                datetime(2013, 1, 1, 12, 30, tzinfo=UTC()),
+                datetime(2013, 1, 1, 12, tzinfo=pytz.utc),
+                datetime(2013, 1, 1, 12, 30, tzinfo=pytz.utc),
             ),
         ),
     ]

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -24,6 +24,7 @@ def test_reverse_iso8601_datetime():
     dates = [
         ("2011-01-01T00:00:00+00:00", datetime(2011, 1, 1, tzinfo=pytz.utc)),
         ("2011-01-01T23:59:59+00:00", datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.utc)),
+        ("2011-01-01T23:59:59.001000+00:00", datetime(2011, 1, 1, 23, 59, 59, 1000, tzinfo=pytz.utc)),
         ("2011-01-01T23:59:59+02:00", datetime(2011, 1, 1, 21, 59, 59, tzinfo=pytz.utc))
     ]
 

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -9,34 +9,6 @@ import six
 from flask_restful import inputs
 
 
-def test_rfc822_datetime_formatters():
-    dates = [
-        (datetime(2011, 1, 1), "Sat, 01 Jan 2011 00:00:00 -0000"),
-        (datetime(2011, 1, 1, 23, 59, 59),
-         "Sat, 01 Jan 2011 23:59:59 -0000"),
-        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.utc),
-         "Sat, 01 Jan 2011 23:59:59 -0000"),
-        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.timezone('CET')),
-         "Sat, 01 Jan 2011 22:59:59 -0000")
-    ]
-    for date_obj, expected in dates:
-        yield assert_equal, inputs.rfc822(date_obj), expected
-
-
-def test_iso8601_datetime_formatters():
-    dates = [
-        (datetime(2011, 1, 1), "2011-01-01T00:00:00+00:00"),
-        (datetime(2011, 1, 1, 23, 59, 59),
-         "2011-01-01T23:59:59+00:00"),
-        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.utc),
-         "2011-01-01T23:59:59+00:00"),
-        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.timezone('CET')),
-         "2011-01-01T22:59:59+00:00")
-    ]
-    for date_obj, expected in dates:
-        yield assert_equal, inputs.iso8601(date_obj), expected
-
-
 def test_reverse_rfc822_datetime():
     dates = [
         ("Sat, 01 Jan 2011 00:00:00 -0000", datetime(2011, 1, 1, tzinfo=pytz.utc)),


### PR DESCRIPTION
Also fixes forced conversion to UTC as noted by @ianozsvald [here](https://github.com/flask-restful/flask-restful/issues/368#issuecomment-69040032)