### PR TITLE
String arguments parsing `null` from JSON as string "None"

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -108,6 +108,11 @@ class Argument(object):
         if value is None and inspect.isclass(self.type) and issubclass(self.type, six.string_types):
             return None
 
+        # and check if we're expecting a filestorage and haven't overridden `type`
+        # (required because the below instantiation isn't valid for FileStorage)
+        elif isinstance(value, FileStorage) and self.type == FileStorage:
+            return value
+
         try:
             return self.type(value, self.name, op)
         except TypeError:
@@ -152,25 +157,26 @@ class Argument(object):
                     values = [source.get(name)]
 
                 for value in values:
-                    if not isinstance(value, FileStorage):
-                        if not self.case_sensitive:
-                            value = value.lower()
-                            if hasattr(self.choices, "__iter__"):
-                                self.choices = [choice.lower() for choice in self.choices]
+                    if hasattr(value, "lower") and not self.case_sensitive:
+                        value = value.lower()
 
-                        try:
-                            value = self.convert(value, operator)
-                        except Exception as error:
-                            if self.ignore:
-                                continue
-                            self.handle_validation_error(error)
+                        if hasattr(self.choices, "__iter__"):
+                            self.choices = [choice.lower()
+                                            for choice in self.choices]
 
-                        if self.choices and value not in self.choices:
-                            self.handle_validation_error(
-                                ValueError(u"{0} is not a valid choice".format(
-                                    value
-                                ))
-                            )
+                    try:
+                        value = self.convert(value, operator)
+                    except Exception as error:
+                        if self.ignore:
+                            continue
+                        self.handle_validation_error(error)
+
+                    if self.choices and value not in self.choices:
+                        self.handle_validation_error(
+                            ValueError(u"{0} is not a valid choice".format(
+                                value
+                            ))
+                        )
 
                     if name in request.unparsed_arguments:
                         request.unparsed_arguments.pop(name)

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -569,6 +569,28 @@ class ReqParseTestCase(unittest.TestCase):
             self.assertEquals(args['foo'].filename, 'baz.txt')
             self.assertEquals(args['foo'].read(), fdata)
 
+    def test_filestorage_custom_type(self):
+        def _custom_type(f):
+            return FileStorage(stream=f.stream,
+                               filename="{0}aaaa".format(f.filename),
+                               name="{0}aaaa".format(f.name))
+
+        app = Flask(__name__)
+
+        parser = RequestParser()
+        parser.add_argument("foo", type=_custom_type, location='files')
+
+        fdata = six.b('foo bar baz qux')
+        with app.test_request_context('/bubble', method='POST',
+                                      data={'foo': (six.BytesIO(fdata), 'baz.txt')}):
+            args = parser.parse_args()
+
+            self.assertEquals(args['foo'].name, 'fooaaaa')
+            self.assertEquals(args['foo'].filename, 'baz.txtaaaa')
+            self.assertEquals(args['foo'].read(), fdata)
+
+
+
     def test_passing_arguments_object(self):
         req = Request.from_values("/bubble?foo=bar")
         parser = RequestParser()


### PR DESCRIPTION
#159 introduced a bug where the following happens:

```python
parser = RequestParser()
parser.add_argument('name')
```

```
POST /foo {"name": null}
```

```python
args = parser.parse_args()
# resulting args:
{'name': 'None'}
```

There was (is) a check for skipping a cast to a string if the input is string but the value in the `request` is `None` [here](https://github.com/flask-restful/flask-restful/blob/0.3.1/flask_restful/reqparse.py#L107-L109), but 442db82 altered the default `type` of `Argument` such that it no longer works:

```python
>>> import six, inspect
>>> value = None
# Before 442db82
>>> arg_type = six.text_type
>>> value is None and inspect.isclass(arg_type) and issubclass(arg_type, six.string_types)
True
# After 442db82
>>> arg_type = lambda x: six.text_type(x)
>>> s is None and inspect.isclass(arg_type) and issubclass(arg_type, six.string_types)
False
>>> type(six.text_type)
<type 'type'>
>>> type(text_type)
<type 'function'>
```