### PR TITLE
String arguments parsing `null` from JSON as string "None"

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -104,8 +104,8 @@ class Argument(object):
         return MultiDict()
 
     def convert(self, value, op):
-        # check if we're expecting a string and the value is `None`
-        if value is None and inspect.isclass(self.type) and issubclass(self.type, six.string_types):
+        # Don't cast None
+        if value is None:
             return None
 
         # and check if we're expecting a filestorage and haven't overridden `type`

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -150,6 +150,11 @@ class ReqParseTestCase(unittest.TestCase):
         arg = Argument('foo', location=['headers'])
         self.assertEquals(arg.source(req), MultiDict(req.headers))
 
+    def test_convert_default_type_with_null_input(self):
+        """convert() should properly handle case where input is None"""
+        arg = Argument('foo')
+        self.assertEquals(arg.convert(None, None), None)
+
     def test_source_bad_location(self):
         req = Mock(['values'])
         arg = Argument('foo', location=['foo'])


### PR DESCRIPTION
#159 introduced a bug where the following happens:

```python
parser = RequestParser()
parser.add_argument('name')
```

```
POST /foo {"name": null}
```

```python
args = parser.parse_args()
# resulting args:
{'name': 'None'}
```

There was (is) a check for skipping a cast to a string if the input is string but the value in the `request` is `None` [here](https://github.com/flask-restful/flask-restful/blob/0.3.1/flask_restful/reqparse.py#L107-L109), but 442db82 altered the default `type` of `Argument` such that it no longer works:

```python
>>> import six, inspect
>>> value = None
# Before 442db82
>>> arg_type = six.text_type
>>> value is None and inspect.isclass(arg_type) and issubclass(arg_type, six.string_types)
True
# After 442db82
>>> arg_type = lambda x: six.text_type(x)
>>> s is None and inspect.isclass(arg_type) and issubclass(arg_type, six.string_types)
False
>>> type(six.text_type)
<type 'type'>
>>> type(text_type)
<type 'function'>
```