### PR TITLE
Fix url_for when used with Blueprints 

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -451,8 +451,13 @@ class Api(object):
         return wrapper
 
     def url_for(self, resource, **values):
-        """Generates a URL to the given resource."""
-        return url_for(resource.endpoint, **values)
+        """Generates a URL to the given resource.
+
+        Works like :func:`flask.url_for`."""
+        endpoint = resource.endpoint
+        if self.blueprint:
+            endpoint = '{0}.{1}'.format(self.blueprint.name, endpoint)
+        return url_for(endpoint, **values)
 
     def make_response(self, data, *args, **kwargs):
         """Looks up the representation transformer for the requested media

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,5 @@
 import unittest
-from flask import Flask, redirect, views
+from flask import Flask, Blueprint, redirect, views
 from flask.signals import got_request_exception, signals_available
 try:
     from mock import Mock, patch
@@ -730,6 +730,18 @@ class APITestCase(unittest.TestCase):
         api.add_resource(HelloWorld, '/ids/<int:id>')
         with app.test_request_context('/foo'):
             self.assertEqual(api.url_for(HelloWorld, id=123), '/ids/123')
+
+    def test_url_for_with_blueprint(self):
+        """Verify that url_for works when an Api object is mounted on a
+        Blueprint.
+        """
+        api_bp = Blueprint('api', __name__)
+        app = Flask(__name__)
+        api = flask_restful.Api(api_bp)
+        api.add_resource(HelloWorld, '/foo/<string:bar>')
+        app.register_blueprint(api_bp)
+        with app.test_request_context('/foo'):
+            self.assertEqual(api.url_for(HelloWorld, bar='baz'), '/foo/baz')
 
     def test_fr_405(self):
         app = Flask(__name__)


### PR DESCRIPTION
Fixes #396

Example:
```python
from flask import Flask, Blueprint
from flask.ext.restful import Api, Resource, url_for

app = Flask(__name__)
api_bp = Blueprint('api', __name__)
api = Api(api_bp, prefix='/api')

class PersonApi(Resource):
    def get(self, uuid=None):
        return api.url_for(PersonApi, uuid=uuid)

api.add_resource(PersonApi, '/persons/<string:uuid>', endpoint='persons_ep')
app.register_blueprint(api_bp)

if __name__ == '__main__':
    app.run(debug=True)
```

@mjmare / @systemkeeper could you test this fix with your applications by `pip install`-ing or adding `git+https://github.com/flask-restful/flask-restful.git@72afe1aba68a61dba0c84d180364c9d2fd50fbd6` to your `requirements.txt`?