### PR TITLE
Allow any callables to be used as lazy attributes.

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from calendar import timegm
 import pytz
-from inspect import isfunction
 from decimal import Decimal as MyDecimal, ROUND_HALF_EVEN
 from email.utils import formatdate
 import six
@@ -38,7 +37,7 @@ def get_value(key, obj, default=None):
     """Helper for pulling a keyed value off various types of objects"""
     if type(key) == int:
         return _get_value_for_key(key, obj, default)
-    elif isfunction(key):
+    elif callable(key):
         return key(obj)
     else:
         return _get_value_for_keys(key.split('.'), obj, default)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from functools import partial
 import pytz
 import unittest
 from mock import Mock
@@ -164,6 +165,15 @@ class FieldsTestCase(unittest.TestCase):
     def test_string_with_lambda(self):
         field = fields.String(attribute=lambda x: x.hey)
         self.assertEquals("3", field.output("foo", Foo()))
+
+    def test_string_with_partial(self):
+
+        def f(x, suffix):
+            return "%s-%s" % (x.hey, suffix)
+
+        p = partial(f, suffix="whatever")
+        field = fields.String(attribute=p)
+        self.assertEquals("3-whatever", field.output("foo", Foo()))
 
     def test_url_invalid_object(self):
         app = Flask(__name__)


### PR DESCRIPTION
Is there any reason that the `inspect.isfunction` is being used instead of the `callable()` builtin? This small patch allows people to use any callable, in my use case partial functions.