### PR TITLE
Email input parser and tests, fixes issue #407

### DIFF
--- a/flask_restful/inputs.py
+++ b/flask_restful/inputs.py
@@ -313,7 +313,8 @@ def _valid_domain_part(domain_part):
         if _valid_ipv4(ip_address) or _valid_ipv6(ip_address):
             return True
     # check for IDN domain
-    if domain_regex.match(domain_part.encode('idna')):
+    idn = domain_part.encode('idna').decode('ascii')
+    if domain_regex.match(idn):
         return True
     raise ValueError("Invalid email domain: %s" % domain_part)
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from decimal import Decimal
 from functools import partial
 import pytz

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from datetime import datetime, timedelta, tzinfo
 import unittest
 import pytz
@@ -396,6 +399,53 @@ def test_bad_isointervals():
             inputs.iso8601interval,
             bad_interval,
         )
+
+def test_email():
+    # These email validator test cases are from Django.
+    good_addresses = [
+        'email@here.com',
+        'weirder-email@here.and.there.com',
+        'email@[127.0.0.1]',
+        'email@[2001:dB8::1]',
+        'email@[2001:dB8:0:0:0:0:0:1]',
+        'email@[::fffF:127.0.0.1]',
+        'example@valid-----hyphens.com',
+        'example@valid-with-hyphens.com',
+        '"test@test"@example.com',
+        'test@domain.with.idn.tld.उदाहरण.परीक्षा',
+        '"\\\011"@here.com',
+        'a@%s.us' % ('a' * 249),
+    ]
+    bad_addresses = [
+        None,
+        '',
+        'abc',
+        'abc@',
+        'abc@bar',
+        'a @x.cz',
+        'abc@.com',
+        'something@@somewhere.com',
+        'email@127.0.0.1',
+        'email@[127.0.0.256]',
+        'email@[2001:db8::12345]',
+        'email@[2001:db8:0:0:0:0:1]',
+        'email@[::ffff:127.0.0.256]',
+        'example@invalid-.com',
+        'example@-invalid.com',
+        'example@invalid.com-',
+        'example@inv-.alid-.com',
+        'example@inv-.-alid.com',
+        'test@example.com\n\n<script src="x.js">',
+        '"\\\012"@here.com',
+        'trailingdot@shouldfail.com.',
+        'a@%s.us' % ('a' * 250),
+    ]
+
+    for each in good_addresses:
+        assert_equal(each, inputs.email(each))
+    for each in bad_addresses:
+        assert_raises(ValueError, inputs.email, each)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is an adaptation of Django's EmailValidator class, and handles all the same test cases. It does *not* currently support internationalized email address user names, as provided for by RFC 6530 and now supported by stable Postfix and some versions of sendmail.

We might want to reuse the domain name checking functions in the URL parser, but that would entail some refactoring. The `url_regex` currently accepts some invalid domains, like 257.0.0.0, and does not handle internationalized (IDN) domains.