### PR TITLE
Trim support with fixes

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -160,7 +160,7 @@ class Argument(object):
                     values = [source.get(name)]
 
                 for value in values:
-                    if self.trim:
+                    if hasattr(value, "strip") and self.trim:
                         value = value.strip()
                     if hasattr(value, "lower") and not self.case_sensitive:
                         value = value.lower()
@@ -250,7 +250,7 @@ class RequestParser(object):
             self.args.append(self.argument_class(*args, **kwargs))
 
         #Do not know what other argument classes are out there
-        if self.trim and type(self.argument_class) is type(Argument):
+        if self.trim and self.argument_class is Argument:
             #enable trim for appended element
             self.args[-1].trim = True
 

--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -61,12 +61,13 @@ class Argument(object):
         case sensitive or not
     :param bool store_missing: Whether the arguments default value should
         be stored if the argument is missing from the request.
+    :param bool trim: If enabled, trims whitespace around the argument.
     """
 
     def __init__(self, name, default=None, dest=None, required=False,
                  ignore=False, type=text_type, location=('json', 'values',),
                  choices=(), action='store', help=None, operators=('=',),
-                 case_sensitive=True, store_missing=True):
+                 case_sensitive=True, store_missing=True, trim=False):
         self.name = name
         self.default = default
         self.dest = dest
@@ -80,6 +81,7 @@ class Argument(object):
         self.case_sensitive = case_sensitive
         self.operators = operators
         self.store_missing = store_missing
+        self.trim = trim
 
     def source(self, request):
         """Pulls values off the request in the provided location
@@ -158,6 +160,8 @@ class Argument(object):
                     values = [source.get(name)]
 
                 for value in values:
+                    if self.trim:
+                        value = value.strip()
                     if hasattr(value, "lower") and not self.case_sensitive:
                         value = value.lower()
 
@@ -220,12 +224,15 @@ class RequestParser(object):
         parser.add_argument('foo')
         parser.add_argument('int_bar', type=int)
         args = parser.parse_args()
+
+    :param bool trim: If enabled, trims whitespace on all arguments in this parser
     """
 
-    def __init__(self, argument_class=Argument, namespace_class=Namespace):
+    def __init__(self, argument_class=Argument, namespace_class=Namespace, trim=False):
         self.args = []
         self.argument_class = argument_class
         self.namespace_class = namespace_class
+        self.trim = trim
 
     def add_argument(self, *args, **kwargs):
         """Adds an argument to be parsed.
@@ -236,10 +243,17 @@ class RequestParser(object):
         See :class:`Argument`'s constructor for documentation on the
         available options.
         """
+
         if len(args) == 1 and isinstance(args[0], self.argument_class):
             self.args.append(args[0])
         else:
             self.args.append(self.argument_class(*args, **kwargs))
+
+        #Do not know what other argument classes are out there
+        if self.trim and type(self.argument_class) is type(Argument):
+            #enable trim for appended element
+            self.args[-1].trim = True
+
         return self
 
     def parse_args(self, req=None, strict=False):

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -757,5 +757,21 @@ class ReqParseTestCase(unittest.TestCase):
         args = parser.parse_args(req)
         self.assertEquals(args['foo'], 1)
 
+    def test_trim_request_parser_json(self):
+        app = Flask(__name__)
+
+        parser = RequestParser(trim=True)
+        parser.add_argument("foo", location="json")
+        parser.add_argument("int1", location="json", type=int)
+        parser.add_argument("int2", location="json", type=int)
+
+        with app.test_request_context('/bubble', method="post",
+                                      data=json.dumps({"foo": " bar ", "int1": 1, "int2": " 2 "}),
+                                      content_type='application/json'):
+            args = parser.parse_args()
+            self.assertEquals(args['foo'], 'bar')
+            self.assertEquals(args['int1'], 1)
+            self.assertEquals(args['int2'], 2)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -723,6 +723,39 @@ class ReqParseTestCase(unittest.TestCase):
         parser.add_argument('foo', type=int)
         self.assertRaises(exceptions.BadRequest, parser.parse_args, req, strict=True)
 
+    def test_trim_argument(self):
+        req = Request.from_values("/bubble?foo= 1 &bar=bees&n=22")
+        parser = RequestParser()
+        parser.add_argument('foo')
+        args = parser.parse_args(req)
+        self.assertEquals(args['foo'], ' 1 ')
+
+        parser = RequestParser()
+        parser.add_argument('foo', trim=True)
+        args = parser.parse_args(req)
+        self.assertEquals(args['foo'], '1')
+
+        parser = RequestParser()
+        parser.add_argument('foo', trim=True, type=int)
+        args = parser.parse_args(req)
+        self.assertEquals(args['foo'], 1)
+
+    def test_trim_request_parser(self):
+        req = Request.from_values("/bubble?foo= 1 &bar=bees&n=22")
+        parser = RequestParser(trim=False)
+        parser.add_argument('foo')
+        args = parser.parse_args(req)
+        self.assertEquals(args['foo'], ' 1 ')
+
+        parser = RequestParser(trim=True)
+        parser.add_argument('foo')
+        args = parser.parse_args(req)
+        self.assertEquals(args['foo'], '1')
+
+        parser = RequestParser(trim=True)
+        parser.add_argument('foo', type=int)
+        args = parser.parse_args(req)
+        self.assertEquals(args['foo'], 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Thanks for feedback, improved the shortcomings and responded to your comments:
https://github.com/flask-restful/flask-restful/pull/427/files#r28646182

I would really like to be able to set the trimming on RequestParser level. The reason is that for back-ends that handle form submissions, a whitespace can be submitted on any input field. In an ideal world trimming could be configured on an application level, however that's too much asked for now :)