### PR TITLE
Fix custom type docs on "Intermediate usage" and docstring

### DIFF
--- a/docs/intermediate-usage.rst
+++ b/docs/intermediate-usage.rst
@@ -109,11 +109,11 @@ exercise a larger amount of options. We'll define a resource named "User". ::
     from flask_restful import fields, marshal_with, reqparse, Resource
 
     def email(email_str):
-        """ return True if email_str is a valid email """
-        if valid_email(email):
-            return True
+        """Return email_str if valid, raise an exception in other case."""
+        if valid_email(email_str):
+            return email_str
         else:
-            raise ValidationError("{} is not a valid email")
+            raise ValueError('{} is not a valid email'.format(email_str))
 
     post_parser = reqparse.RequestParser()
     post_parser.add_argument(
@@ -183,9 +183,9 @@ of 'the username field is required'. ::
     )
 
 The ``email`` field has a custom type of ``email``. A few lines earlier we
-defined an ``email`` function that takes a string and returns ``True`` if the
-type is valid, else it raises a ``ValidationError`` exclaiming that the
-email type was invalid. ::
+defined an ``email`` function that takes a string and returns it if the type is
+valid, else it raises an exception, exclaiming that the email type was
+invalid. ::
 
     post_parser.add_argument(
         'user_priority', dest='user_priority',

--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -47,7 +47,7 @@ class Argument(object):
     :param ignore: Whether to ignore cases where the argument fails type
         conversion
     :param type: The type to which the request argument should be
-        converted. If a type raises a ValidationError, the message in the
+        converted. If a type raises an exception, the message in the
         error will be returned in the response. Defaults to :class:`unicode`
         in python2 and :class:`str` in python3.
     :param location: The attributes of the :class:`flask.Request` object
@@ -56,7 +56,7 @@ class Argument(object):
     :param choices: A container of the allowable values for the argument.
     :param help: A brief description of the argument, returned in the
         response when the argument is invalid with the name of the argument and
-        the message passed to a ValidationError raised by a type converter.
+        the message passed to any exception raised by a type converter.
     :param bool case_sensitive: Whether the arguments in the request are
         case sensitive or not
     :param bool store_missing: Whether the arguments default value should


### PR DESCRIPTION
Both the `intermediate usage` example on custom types and the related docstrings in the `Argument` class are quite confussing for newcomers:
- Returning an actual value instead of `True` draws a clearer picture of the expected behaviour one custom type.
- Both the `email` example function and the `Argument` docstring reference a `ValidationError` exception which is not present on source and is actually not required (any raised exception will do for converting/validating types).
