### PR TITLE
Fixed problem with deepcopy

### DIFF
--- a/flask_restful/inputs.py
+++ b/flask_restful/inputs.py
@@ -65,6 +65,9 @@ class regex(object):
             raise ValueError(message)
         return value
 
+    def __deepcopy__(self, memo):
+        return regex(self.pattern)
+
 
 def _normalize_interval(start, end, value):
     """Normalize datetime intervals.


### PR DESCRIPTION
If you will try co copy regex input, you will get an error:
```
TypeError: cannot deepcopy this pattern object
```