### PR TITLE
Explicitly check the class type for propagate_exceptions 

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -274,7 +274,7 @@ class Api(object):
         """
         got_request_exception.send(current_app._get_current_object(), exception=e)
 
-        if not hasattr(e, 'code') and current_app.propagate_exceptions:
+        if not isinstance(e, HTTPException) and current_app.propagate_exceptions:
             exc_type, exc_value, tb = sys.exc_info()
             if exc_value is e:
                 raise


### PR DESCRIPTION
This is a modification of https://github.com/flask-restful/flask-restful/pull/111

The problem with the hasattr check is that it forces an arbitrary restriction on the types of exceptions that can be thrown - The exception (or any base class) cannot have an attribute named 'code'. In practice this leads to a very confusing flow where some exceptions appear to work properly but not others. I personally spent a lot of time pulling my hair trying to figure out why one particular exception wasn't working properly in our system.

My belief (would be great if someone could confirm) is that the original goal was to catch werkzeug exceptions and handle them.
http://werkzeug.pocoo.org/docs/0.10/exceptions/#baseclass

So this change makes an explicit instance check against HTTPException rather than duck typing for 'code'.