### PR TITLE
Allow exceptions to specify headers

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -287,7 +287,7 @@ class Api(object):
                 raise e
         code = getattr(e, 'code', 500)
         data = getattr(e, 'data', error_data(code))
-        headers = {}
+        headers = getattr(e, 'headers', {})
 
         if code >= 500:
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -76,6 +76,7 @@ class APITestCase(unittest.TestCase):
         api = flask_restful.Api(app)
         exception = Mock()
         exception.code = 401
+        exception.headers = {}
         exception.data = {'foo': 'bar'}
 
         with app.test_request_context('/foo'):
@@ -88,6 +89,7 @@ class APITestCase(unittest.TestCase):
         api = flask_restful.Api(app, serve_challenge_on_401=True)
         exception = Mock()
         exception.code = 401
+        exception.headers = {}
         exception.data = {'foo': 'bar'}
 
         with app.test_request_context('/foo'):
@@ -102,6 +104,7 @@ class APITestCase(unittest.TestCase):
         api = flask_restful.Api(app, serve_challenge_on_401=True)
         exception = Mock()
         exception.code = 401
+        exception.headers = {}
         exception.data = {'foo': 'bar'}
 
         with app.test_request_context('/foo'):
@@ -356,6 +359,7 @@ class APITestCase(unittest.TestCase):
 
         exception = Mock()
         exception.code = 500
+        exception.headers = {}
         exception.data = {'foo': 'bar'}
 
         with app.test_request_context("/foo"):
@@ -371,6 +375,7 @@ class APITestCase(unittest.TestCase):
 
         exception = Mock()
         exception.code = 401
+        exception.headers = {}
         exception.data = {'foo': 'bar'}
 
         with app.test_request_context("/foo"):
@@ -425,6 +430,7 @@ class APITestCase(unittest.TestCase):
 
         exception = Mock()
         exception.code = 400
+        exception.headers = {}
         exception.data = {'foo': 'bar'}
 
         recorded = []
@@ -447,11 +453,13 @@ class APITestCase(unittest.TestCase):
 
         exception = Mock()
         exception.code = 400
+        exception.headers = {"X-Something": "OK"}
         exception.data = {'foo': 'bar'}
 
         with app.test_request_context("/foo"):
             resp = api.handle_error(exception)
             self.assertEquals(resp.status_code, 400)
+            self.assertEqual(resp.headers.get("X-Something"), "OK")
             self.assertEquals(resp.data.decode(), dumps({
                 'foo': 'bar',
             }))
@@ -464,6 +472,7 @@ class APITestCase(unittest.TestCase):
         exception = Mock()
         exception.code = 404
         exception.data = {"status": 404, "message": "Not Found"}
+        exception.headers = {}
         api.add_resource(view, '/foo', endpoint='bor')
         api.add_resource(view, '/fee', endpoint='bir')
         api.add_resource(view, '/fii', endpoint='ber')


### PR DESCRIPTION
This small change allows exceptions to specify custom headers.

This can be helpful for "401 Unauthorized" exceptions that want to provide a custom value for the `WWW-Authenticate` header. Currently, it's either `Basic` auth or nothing. There are many other reasons an exception could want to provide a custom header as well (automated health checks and provisional cache control come to mind).

Thanks for taking a look.