### PR TITLE
send stacktrace emails on 500

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -16,7 +16,7 @@ import sys
 from flask.helpers import _endpoint_from_view_func
 from types import MethodType
 import operator
-
+from flask_restful.utils.mail_error import email_exception
 
 __all__ = ('Api', 'Resource', 'marshal', 'marshal_with', 'marshal_with_field', 'abort')
 
@@ -267,6 +267,9 @@ class Api(object):
                 return self.handle_error(e)
             except Exception:
                 pass  # Fall through to original handler
+            else:
+                email_exception(e)
+
         return original_handler(e)
 
     def handle_error(self, e):

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -17,7 +17,7 @@ from flask.helpers import _endpoint_from_view_func
 from types import MethodType
 import operator
 from flask_restful.utils.mail_error import email_exception
-from flask_mail import Mail as __Mail
+
 
 __all__ = ('Api', 'Resource', 'marshal', 'marshal_with', 'marshal_with_field', 'abort')
 
@@ -119,6 +119,7 @@ class Api(object):
         else:
             self.blueprint = app
 
+        from flask_mail import Mail as __Mail
         self.mail = __Mail(app)
 
     def _complete_url(self, url_part, registration_prefix):

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -119,8 +119,6 @@ class Api(object):
         else:
             self.blueprint = app
 
-        from flask_mail import Mail as __Mail
-        self.mail = __Mail(app)
 
     def _complete_url(self, url_part, registration_prefix):
         """This method is used to defer the construction of the final url in
@@ -195,6 +193,10 @@ class Api(object):
         :param app: The flask application object
         :type app: flask.Flask
         """
+
+        from flask_mail import Mail as __Mail
+        self.mail = __Mail(app)
+
         app.handle_exception = partial(self.error_router, app.handle_exception)
         app.handle_user_exception = partial(self.error_router, app.handle_user_exception)
 

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -17,6 +17,7 @@ from flask.helpers import _endpoint_from_view_func
 from types import MethodType
 import operator
 from flask_restful.utils.mail_error import email_exception
+from flask_mail import Mail as __Mail
 
 __all__ = ('Api', 'Resource', 'marshal', 'marshal_with', 'marshal_with_field', 'abort')
 
@@ -117,6 +118,8 @@ class Api(object):
             self._init_app(app)
         else:
             self.blueprint = app
+
+        self.mail = __Mail(app)
 
     def _complete_url(self, url_part, registration_prefix):
         """This method is used to defer the construction of the final url in
@@ -264,11 +267,14 @@ class Api(object):
         """
         if self._has_fr_route():
             try:
+                email_exception(self.mail, e)
+            except:
+                pass
+
+            try:
                 return self.handle_error(e)
             except Exception:
                 pass  # Fall through to original handler
-            else:
-                email_exception(e)
 
         return original_handler(e)
 

--- a/flask_restful/utils/mail_error.py
+++ b/flask_restful/utils/mail_error.py
@@ -6,14 +6,12 @@ import traceback
 
 from flask import request as __request
 from flask import current_app
-from flask_mail import Mail as __Mail
 from flask_mail import Message as __Message
 
 
-mail = __Mail(current_app)
 
 # create a closure to track the sender and recipients
-def email_exception(exception):
+def email_exception(mail, exception):
     try:
         current_app.config['DEFAULT_MAIL_SENDER']
         current_app.config['ADMINISTRATORS']
@@ -37,5 +35,7 @@ def email_exception(exception):
         msg_contents.append('%s: %s' % (key, environ.get(key)))
 
     msg.body = '\n'.join(msg_contents) + '\n'
-
-    mail.send(msg)
+    try:
+        mail.send(msg)
+    except:
+         current_app.logger.exception("Error send email")

--- a/flask_restful/utils/mail_error.py
+++ b/flask_restful/utils/mail_error.py
@@ -1,0 +1,41 @@
+# _*_ coding: utf-8 _*_
+
+__author__ = 'radik'
+
+import traceback
+
+from flask import request as __request
+from flask import current_app
+from flask_mail import Mail as __Mail
+from flask_mail import Message as __Message
+
+
+mail = __Mail(current_app)
+
+# create a closure to track the sender and recipients
+def email_exception(exception):
+    try:
+        current_app.config['DEFAULT_MAIL_SENDER']
+        current_app.config['ADMINISTRATORS']
+    except KeyError:
+        return
+
+    msg = __Message("[Flask|ErrorMail] Exception Detected: %s" % exception.message,
+                    sender=current_app.config['DEFAULT_MAIL_SENDER'],
+                    recipients=current_app.config['ADMINISTRATORS'])
+    msg_contents = [
+        'Traceback:',
+        '='*80,
+        traceback.format_exc(),
+    ]
+    msg_contents.append('\n')
+    msg_contents.append('Request Information:')
+    msg_contents.append('='*80)
+    environ = __request.environ
+    environkeys = sorted(environ.keys())
+    for key in environkeys:
+        msg_contents.append('%s: %s' % (key, environ.get(key)))
+
+    msg.body = '\n'.join(msg_contents) + '\n'
+
+    mail.send(msg)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = [
     'Flask>=0.8',
     'six>=1.3.0',
     'pytz',
-    'Flask-ErrorMail==0.2.2'
+    'Flask-Mail==0.9.1'
 ]
 if PY26:
     requirements.append('ordereddict')

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ requirements = [
     'Flask>=0.8',
     'six>=1.3.0',
     'pytz',
+    'Flask-ErrorMail==0.2.2'
 ]
 if PY26:
     requirements.append('ordereddict')


### PR DESCRIPTION
It is provides a simple tool for configuring your Flask application to automatically send stacktrace emails to a list of administrators whenever an Internal Server Error happens.

example config:

app = Flask(__name__)

app.config['MAIL_SERVER'] = 'mail.ya.ru'
app.config['EMAIL_PORT'] = 465
app.config['MAIL_USERNAME'] = 'ex@example.com'
app.config['MAIL_PASSWORD'] = '123456'
app.config['DEFAULT_MAIL_SENDER'] = 'ex@example.com'
app.config['ADMINISTRATORS'] = ['haziev.radik@smartcity.com.sg',]

api = Api(app)
