### PR TITLE
Pull json.dumps settings from application configuration

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,6 +4,7 @@ Authors
 A huge thanks to all of our contributors:
 
 
+- Alec Reiter
 - Alex Gaynor
 - Alex M
 - Alex Morken

--- a/flask_restful/representations/json.py
+++ b/flask_restful/representations/json.py
@@ -3,27 +3,21 @@ from flask import make_response, current_app
 from json import dumps
 
 
-# This dictionary contains any kwargs that are to be passed to the json.dumps
-# function, used below.
-settings = {}
-
-
 def output_json(data, code, headers=None):
     """Makes a Flask response with a JSON encoded body"""
+
+    settings = current_app.config.get('RESTFUL_JSON', {})
 
     # If we're in debug mode, and the indent is not set, we set it to a
     # reasonable value here.  Note that this won't override any existing value
     # that was set.  We also set the "sort_keys" value.
-    local_settings = settings.copy()
     if current_app.debug:
-        local_settings.setdefault('indent', 4)
-        local_settings.setdefault('sort_keys', True)
+        settings.setdefault('indent', 4)
+        settings.setdefault('sort_keys', True)
 
-    # We also add a trailing newline to the dumped JSON if the indent value is
-    # set - this makes using `curl` on the command line much nicer.
-    dumped = dumps(data, **local_settings)
-    if 'indent' in local_settings:
-        dumped += '\n'
+    # always end the json dumps with a new line
+    # see https://github.com/mitsuhiko/flask/pull/1262
+    dumped = dumps(data, **settings) + "\n"
 
     resp = make_response(dumped, code)
     resp.headers.extend(headers or {})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,17 +2,17 @@ import unittest
 from flask import Flask, Blueprint, redirect, views
 from flask.signals import got_request_exception, signals_available
 try:
-    from mock import Mock, patch
+    from mock import Mock
 except:
     # python3
-    from unittest.mock import Mock, patch
+    from unittest.mock import Mock
 import flask
 import werkzeug
 from flask_restful.utils import http_status_message, error_data, unpack
 import flask_restful
 import flask_restful.fields
 from flask_restful import OrderedDict
-from json import dumps, loads
+from json import dumps, loads, JSONEncoder
 #noinspection PyUnresolvedReferences
 from nose.tools import assert_equals, assert_true, assert_false  # you need it for tests in form of continuations
 import six
@@ -363,7 +363,7 @@ class APITestCase(unittest.TestCase):
             self.assertEquals(resp.status_code, 500)
             self.assertEquals(resp.data.decode(), dumps({
                 'foo': 'bar',
-            }))
+            }) + "\n")
 
     def test_handle_auth(self):
         app = Flask(__name__)
@@ -376,7 +376,7 @@ class APITestCase(unittest.TestCase):
         with app.test_request_context("/foo"):
             resp = api.handle_error(exception)
             self.assertEquals(resp.status_code, 401)
-            self.assertEquals(resp.data.decode(), dumps({'foo': 'bar'}))
+            self.assertEquals(resp.data.decode(), dumps({'foo': 'bar'}) + "\n")
 
             self.assertTrue('WWW-Authenticate' in resp.headers)
 
@@ -454,7 +454,7 @@ class APITestCase(unittest.TestCase):
             self.assertEquals(resp.status_code, 400)
             self.assertEquals(resp.data.decode(), dumps({
                 'foo': 'bar',
-            }))
+            }) + "\n")
 
     def test_handle_smart_errors(self):
         app = Flask(__name__)
@@ -473,14 +473,14 @@ class APITestCase(unittest.TestCase):
             self.assertEquals(resp.status_code, 404)
             self.assertEquals(resp.data.decode(), dumps({
                 "status": 404, "message": "Not Found",
-            }))
+            }) + "\n")
 
         with app.test_request_context("/fOo"):
             resp = api.handle_error(exception)
             self.assertEquals(resp.status_code, 404)
             self.assertEquals(resp.data.decode(), dumps({
                 "status": 404, "message": "Not Found. You have requested this URI [/fOo] but did you mean /foo ?",
-            }))
+            }) + "\n")
 
         with app.test_request_context("/fOo"):
             del exception.data["message"]
@@ -488,7 +488,7 @@ class APITestCase(unittest.TestCase):
             self.assertEquals(resp.status_code, 404)
             self.assertEquals(resp.data.decode(), dumps({
                 "status": 404, "message": "You have requested this URI [/fOo] but did you mean /foo ?",
-            }))
+            }) + "\n")
 
         app.config['ERROR_404_HELP'] = False
 
@@ -498,7 +498,7 @@ class APITestCase(unittest.TestCase):
             self.assertEquals(resp.status_code, 404)
             self.assertEquals(resp.data.decode(), dumps({
                 "status": 404
-            }))
+            }) + "\n")
 
     def test_error_router_falls_back_to_original(self):
         """Verify that if an exception occurs in the Flask-RESTful error handler,
@@ -598,9 +598,9 @@ class APITestCase(unittest.TestCase):
 
         with app.test_client() as client:
             foo1 = client.get('/foo')
-            self.assertEquals(foo1.data, b'"foo1"')
+            self.assertEquals(foo1.data, b'"foo1"\n')
             foo2 = client.get('/foo/toto')
-            self.assertEquals(foo2.data, b'"foo1"')
+            self.assertEquals(foo2.data, b'"foo1"\n')
 
     def test_add_resource(self):
         app = Mock(flask.Flask)
@@ -654,7 +654,7 @@ class APITestCase(unittest.TestCase):
 
         with app.test_client() as client:
             foo = client.get('/foo')
-            self.assertEquals(foo.data, b'"wonderful slurm"')
+            self.assertEquals(foo.data, b'"wonderful slurm"\n')
 
     def test_output_unpack(self):
 
@@ -668,7 +668,7 @@ class APITestCase(unittest.TestCase):
             wrapper = api.output(make_empty_response)
             resp = wrapper()
             self.assertEquals(resp.status_code, 200)
-            self.assertEquals(resp.data.decode(), '{"foo": "bar"}')
+            self.assertEquals(resp.data.decode(), '{"foo": "bar"}\n')
 
     def test_output_func(self):
 
@@ -822,34 +822,69 @@ class APITestCase(unittest.TestCase):
             # Assert our trailing newline.
             self.assertTrue(foo.data.endswith(b'\n'))
 
-    def test_will_pass_options_to_json(self):
+    def test_read_json_settings_from_config(self):
+        class TestConfig(object):
+            RESTFUL_JSON = {'indent': 2,
+                            'sort_keys': True,
+                            'separators': (', ', ': ')}
 
+        app = Flask(__name__)
+        app.config.from_object(TestConfig)
+        api = flask_restful.Api(app)
+
+        class Foo(flask_restful.Resource):
+            def get(self):
+                return {'foo': 'bar', 'baz': 'qux'}
+
+        api.add_resource(Foo, '/foo')
+
+        with app.test_client() as client:
+            data = client.get('/foo').data
+
+        expected = b'{\n  "baz": "qux", \n  "foo": "bar"\n}\n'
+
+        self.assertEquals(data, expected)
+
+
+    def test_use_custom_jsonencoder(self):
+        class CabageEncoder(JSONEncoder):
+            def default(self, obj):
+                return 'cabbage'
+
+        class TestConfig(object):
+            RESTFUL_JSON = {'cls': CabageEncoder}
+
+        app = Flask(__name__)
+        app.config.from_object(TestConfig)
+        api = flask_restful.Api(app)
+
+        class Cabbage(flask_restful.Resource):
+            def get(self):
+                return {'frob': object()}
+
+        api.add_resource(Cabbage, '/cabbage')
+
+        with app.test_client() as client:
+            data = client.get('/cabbage').data
+
+        expected = b'{"frob": "cabbage"}\n'
+        self.assertEquals(data, expected)
+
+    def test_json_with_no_settings(self):
         app = Flask(__name__)
         api = flask_restful.Api(app)
 
-        class Foo1(flask_restful.Resource):
+        class Foo(flask_restful.Resource):
             def get(self):
                 return {'foo': 'bar'}
 
-        api.add_resource(Foo1, '/foo', endpoint='bar')
+        api.add_resource(Foo, '/foo')
 
-        # We patch the representations module here, with two things:
-        #   1. Set the settings dict() with some value
-        #   2. Patch the json.dumps function in the module with a Mock object.
+        with app.test_client() as client:
+            data = client.get('/foo').data
 
-        from flask_restful.representations import json as json_rep
-        json_dumps_mock = Mock(return_value='bar')
-        new_settings = {'indent': 123}
-
-        with patch.multiple(json_rep, dumps=json_dumps_mock,
-                            settings=new_settings):
-            with app.test_client() as client:
-                client.get('/foo')
-
-        # Assert that the function was called with the above settings.
-        data, kwargs = json_dumps_mock.call_args
-        self.assertTrue(json_dumps_mock.called)
-        self.assertEqual(123, kwargs['indent'])
+        expected = b'{"foo": "bar"}\n'
+        self.assertEquals(data, expected)
 
     def test_redirect(self):
         app = Flask(__name__)
@@ -880,7 +915,7 @@ class APITestCase(unittest.TestCase):
         app = app.test_client()
         resp = app.get('/api')
         self.assertEquals(resp.status_code, 200)
-        self.assertEquals(resp.data.decode('utf-8'), '{"foo": 3.0}')
+        self.assertEquals(resp.data.decode('utf-8'), '{"foo": 3.0}\n')
 
     def test_custom_error_message(self):
         errors = {


### PR DESCRIPTION
See: #292, #373 

Allow users to set a `RESTFUL_JSON` dictionary in the application configuration to pull settings from rather than pulling them from a global dictionary. Additionally, a new line is *always* appended to JSON representations See mitsuhiko/flask#1262 for details on this issue. 

I couldn't get tox to build a 3.3 environment, but all tests should pass with it.