### PR TITLE
Update the documentation for Argument.name.

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -5,7 +5,10 @@ import re
 from flask import request, url_for, current_app
 from flask import abort as original_flask_abort
 from flask import make_response as original_flask_make_response
-from flask.views import MethodView
+try:
+    from flask.views import MethodView
+except ImportError:       # can happen for old flask's
+    MethodView = object   # (you can't use Resource with such an old flask)
 from flask.signals import got_request_exception
 from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound, NotAcceptable, InternalServerError
 from werkzeug.http import HTTP_STATUS_CODES

--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -34,8 +34,7 @@ text_type = lambda x: six.text_type(x)
 class Argument(object):
 
     """
-    :param name: Either a name or a list of option strings, e.g. foo or
-        -f, --foo.
+    :param name: The name of this argument, as specified in the HTTP request.
     :param default: The value produced if the argument is absent from the
         request.
     :param dest: The name of the attribute to be added to the object

--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -322,9 +322,10 @@ class RequestParser(object):
 
         if strict and req.unparsed_arguments:
             errors = [{'parameterName': arg,
+                       'parameterValue': value,
                        'parameterDoc': '',
                        'error': 'Unknown argument',
-                      } for arg in req.unparsed_arguments]
+                      } for (arg, value) in req.unparsed_arguments.iteritems()]
             error_fn(400, message=errors)
 
         return namespace

--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -301,8 +301,8 @@ class RequestParser(object):
             flask_restful.abort(400, message=errors)
 
         if strict and req.unparsed_arguments:
-            raise exceptions.BadRequest('Unknown arguments: %s'
-                                        % ', '.join(req.unparsed_arguments.keys()))
+            errors = {arg: 'Unknown argument' for arg in req.unparsed_arguments}
+            flask_restful.abort(400, message=errors)
 
         return namespace
 

--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -140,8 +140,8 @@ class Argument(object):
             bundled
         """
         msg = {
-            "parameter_name": self.name,
-            "parameter_doc": self.help or '',
+            "parameterName": self.name,
+            "parameterDoc": self.help or '',
             "error": str(error),
         }
         if bundle_errors:
@@ -316,8 +316,8 @@ class RequestParser(object):
             error_fn(400, message=errors)
 
         if strict and req.unparsed_arguments:
-            errors = [{'parameter_name': arg,
-                       'parameter_doc': '',
+            errors = [{'parameterName': arg,
+                       'parameterDoc': '',
                        'error': 'Unknown argument',
                       } for arg in req.unparsed_arguments]
             error_fn(400, message=errors)

--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -301,7 +301,8 @@ class RequestParser(object):
             flask_restful.abort(400, message=errors)
 
         if strict and req.unparsed_arguments:
-            errors = {arg: 'Unknown argument' for arg in req.unparsed_arguments}
+            errors = dict([(arg, 'Unknown argument')
+                           for arg in req.unparsed_arguments])
             flask_restful.abort(400, message=errors)
 
         return namespace

--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -141,7 +141,7 @@ class Argument(object):
         """
         help_str = '(%s) ' % self.help if self.help else ''
         error_msg = ' '.join([help_str, str(error)]) if help_str else str(error)
-        if current_app.config.get("BUNDLE_ERRORS", False) or bundle_errors:
+        if bundle_errors:
             msg = {self.name: "%s" % (error_msg)}
             return error, msg
         msg = {self.name: "%s" % (error_msg)}
@@ -191,7 +191,7 @@ class Argument(object):
                         return self.handle_validation_error(error, bundle_errors)
 
                     if self.choices and value not in self.choices:
-                        if current_app.config.get("BUNDLE_ERRORS", False) or bundle_errors:
+                        if bundle_errors:
                             return self.handle_validation_error(
                                 ValueError(u"{0} is not a valid choice".format(
                                     value)), bundle_errors)
@@ -214,7 +214,7 @@ class Argument(object):
                 error_msg = u"Missing required parameter in {0}".format(
                     ' or '.join(friendly_locations)
                 )
-            if current_app.config.get("BUNDLE_ERRORS", False) or bundle_errors:
+            if bundle_errors:
                 return self.handle_validation_error(ValueError(error_msg), bundle_errors)
             self.handle_validation_error(ValueError(error_msg), bundle_errors)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ PY26 = sys.version_info[:2] == (2, 6,)
 
 requirements = [
     'aniso8601>=0.82',
-    'Flask>=0.8',
+    'Flask>=0.6',
     'six>=1.3.0',
     'pytz',
 ]


### PR DESCRIPTION
I don't see anything in the code that indicates it can be a list, and
the example text seems to have to do more with argument parsing than
parameter-parsing anyway.
