### PR TITLE
give resources a ref to their api

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -428,6 +428,7 @@ class Api(object):
 
         resource.mediatypes = self.mediatypes_method()  # Hacky
         resource.endpoint = endpoint
+        resource.api = self
         resource_func = self.output(resource.as_view(endpoint, *resource_class_args,
             **resource_class_kwargs))
 


### PR DESCRIPTION
Working on a project that needs access to [url_for](http://flask-restful.readthedocs.org/en/latest/api.html#flask_restful.Api.url_for).  However, the project's structure does not allow us to easily import the global api object.  This will help us out a lot.
