### PR TITLE
Added possibility to pass extra arguments via fields.Url

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -148,6 +148,23 @@ pass the ``scheme`` keyword argument::
         'https_uri': fields.Url('todo_resource', absolute=True, scheme='https')
     }
 
+It is possible to pass additional arguments resource uri
+synthetisation, for example::
+
+    # somewhere else ...
+    rest.add_resource('/resource/<id>/<action>', endpoint='action_resource')
+
+    # fields
+    fields = {
+        'actions: {
+	    'hello': fields.Url('action_resource', extra={'action': 'hello'}),
+	    'grunt': fields.Url('action_resource', extra={'action': 'grunt'})
+        }
+    }
+
+This decouples the uri syntax from the view as the view does not have
+to know how to add additional path parameters to the resource uri.
+
 Complex Structures
 ------------------
 

--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -293,16 +293,20 @@ class Url(Raw):
     :type absolute: bool
     :param scheme: URL scheme specifier (e.g. ``http``, ``https``)
     :type scheme: str
+    :param extra: Additional values passed to ``url_for``
     """
-    def __init__(self, endpoint=None, absolute=False, scheme=None):
+    def __init__(self, endpoint=None, absolute=False, scheme=None, extra={}):
         super(Url, self).__init__()
         self.endpoint = endpoint
         self.absolute = absolute
         self.scheme = scheme
+        self.extra = extra
 
     def output(self, key, obj):
         try:
             data = to_marshallable_type(obj)
+            if data is not None:
+                data.update(self.extra)
             endpoint = self.endpoint if self.endpoint is not None else request.endpoint
             o = urlparse(url_for(endpoint, _external=self.absolute, **data))
             if self.absolute:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -280,6 +280,14 @@ class FieldsTestCase(unittest.TestCase):
         with app.test_request_context("/foo/hey", base_url="http://localhost"):
             self.assertEquals("https://localhost/foo/3", field.output("hey", Foo()))
 
+    def test_url_with_extra(self):
+        app = Flask(__name__)
+        app.add_url_rule("/<hey>/<what>", "foobar", view_func=lambda x: x)
+        field = fields.Url("foobar", extra={"what": "hello"})
+
+        with app.test_request_context("/hey"):
+            self.assertEquals("/3/hello", field.output("hey", Foo()))
+
     def test_int(self):
         field = fields.Integer()
         self.assertEquals(3, field.output("hey", {'hey': 3}))


### PR DESCRIPTION
I had code that constructed "action URLs" with something like ``url_for(...) + "/dothis"`` and felt it as an unnecessary coupling in the code between the resource location and the view code. From that thought came this pull request.

The idea is to make the pattern of having verbs as part of a resource uri, like ``/res/1/greet``and ``/res/1/fnord`` **and** being able to use ``fields.Url`` to generate such fields in a response:

```
class Res(Resource):
    @marshal_with({'uri': fields.Url,
        'actions': {'greet': fields.Url(extra={'action': 'greet'})}
     })
    def get(self, id, action=None):
        ....


rest.add_resource(Res, '/res/<id>/<action>', endpoint='res')
```

I quickly wrote this and tested it. Comments? 

I'm a bit 50-50 whether this is a good approach or not to the problem (the alternative is really to use ``fields.Raw`` on the ``actions`` part and monkeypatch an ``actions`` field to the object, or to use ``attribute`` to generate the actions hash and use ``url_for`` directly there.)