### PR TITLE
added support to get headers directly from thrown exception if available

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -298,7 +298,7 @@ class Api(object):
             }
 
         data = getattr(e, 'data', default_data)
-        headers = {}
+        headers = getattr(e, 'headers', {})
 
         if code >= 500:
             # There's currently a bug in Python3 that disallows calling


### PR DESCRIPTION
That would make Life so much easier. We need to add CORS headers to the exception to display them in an angularJs Frontend.