### PR TITLE
RFC3339 support, a stricter datetime format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.py[cod]
 env
+venv
 
 # C extensions
 *.so

--- a/flask_restful/inputs.py
+++ b/flask_restful/inputs.py
@@ -3,6 +3,7 @@ from datetime import datetime, time, timedelta
 from email.utils import parsedate_tz, mktime_tz
 import re
 
+import strict_rfc3339
 import aniso8601
 import pytz
 
@@ -278,3 +279,18 @@ def datetime_from_iso8601(datetime_str):
     :return: A datetime
     """
     return aniso8601.parse_datetime(datetime_str)
+
+
+def datetime_from_rfc3339(datetime_str):
+    """Turns an RFC3339 formatted date into a UTC datetime object.
+
+    Example::
+
+        inputs.datetime_from_rfc3339("2013-03-25T12:42:31+00:32")
+
+    :param datetime_str: The RFC3339-complying string to transform
+    :type datetime_str: str
+    :return: A datetime
+    """
+    ts = strict_rfc3339.rfc3339_to_timestamp(datetime_str)
+    return datetime.fromtimestamp(ts, tz=pytz.utc)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ requirements = [
     'Flask>=0.8',
     'six>=1.3.0',
     'pytz',
+    'strict-rfc3339>=0.5'
 ]
 if PY26:
     requirements.append('ordereddict')

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -9,7 +9,7 @@ from flask_restful import fields
 from datetime import datetime, timedelta, tzinfo
 from flask import Flask, Blueprint
 #noinspection PyUnresolvedReferences
-from nose.tools import assert_equals  # you need it for tests in form of continuations
+from nose.tools import assert_equals, assert_raises  # you need it for tests in form of continuations
 
 
 class Foo(object):
@@ -78,6 +78,30 @@ def test_iso8601_datetime_formatters():
     ]
     for date_obj, expected in dates:
         yield assert_equals, fields._iso8601(date_obj), expected
+
+
+def test_rfc3339_datetime_formatters():
+    # no naive datetimes
+    assert_raises(MarshallingException, lambda: fields._rfc3339(datetime(2011, 1, 1)))
+
+    dates = [
+        (datetime(2012, 1, 1, 0, 0, tzinfo=pytz.utc), "2012-01-01T00:00:00Z"),
+        (datetime(2011, 1, 1, tzinfo=pytz.utc), "2011-01-01T00:00:00Z"),
+        (datetime(2011, 1, 1, tzinfo=pytz.timezone('CET')), "2010-12-31T23:00:00Z"),
+        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.utc),
+         "2011-01-01T23:59:59Z"),
+        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.utc),
+         "2011-01-01T23:59:59Z"),
+        (datetime(2011, 1, 1, 23, 59, 59, 1000, tzinfo=pytz.utc),
+         "2011-01-01T23:59:59.001Z"),
+        (datetime(2011, 1, 1, 23, 59, 59, 123456, tzinfo=pytz.utc),
+         "2011-01-01T23:59:59.123456Z"),
+        (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.timezone('CET')),
+         "2011-01-01T22:59:59Z")
+    ]
+
+    for date_obj, expected in dates:
+        yield assert_equals, fields._rfc3339(date_obj), expected
 
 
 class FieldsTestCase(unittest.TestCase):

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, tzinfo
 import unittest
+import strict_rfc3339
 import pytz
 import re
 
@@ -31,6 +32,20 @@ def test_reverse_iso8601_datetime():
 
     for date_string, expected in dates:
         yield assert_equal, inputs.datetime_from_iso8601(date_string), expected
+
+
+def test_reverse_rfc3339_datetime():
+    assert_raises(strict_rfc3339.InvalidRFC3339Error,
+                  lambda: inputs.datetime_from_rfc3339("2011-01-01T00:00:00"))
+
+    dates = [
+        ("2011-01-01T00:00:00+00:00", datetime(2011, 1, 1, tzinfo=pytz.utc)),
+        ("2011-01-01T23:59:59+00:00", datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.utc)),
+        ("2011-01-01T23:59:59+02:00", datetime(2011, 1, 1, 21, 59, 59, tzinfo=pytz.utc))
+    ]
+
+    for date_string, expected in dates:
+        yield assert_equal, inputs.datetime_from_rfc3339(date_string), expected
 
 
 def test_urls():


### PR DESCRIPTION
A format for the DateTime field that forces tz-aware datetimes and formats them using the `strict_rfc3339` package.

I've been burned several times with Python services by using just ISO8601, which allows formatting of naive datetimes and can lead to misinterpretations of datetimes. 

With this enhancement, the user can ensure proper date formatting with the strict RFC3339 spec.