### PR TITLE
For HTTP codes 500 and over, use app object's exception logger

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ Flask-RESTful Changelog
 
 Here you can see the full list of changes between each Flask-RESTful release.
 
+
+- Use Flask's exception log method in `handle_error(e)` method instead of directly logging the exception notice.
+
 Version 0.3.4
 -------------
 

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -301,12 +301,7 @@ class Api(object):
         headers = {}
 
         if code >= 500:
-            # There's currently a bug in Python3 that disallows calling
-            # logging.exception() when an exception hasn't actually be raised
-            if sys.exc_info() == (None, None, None):
-                current_app.logger.error("Internal Error")
-            else:
-                current_app.logger.exception("Internal Error")
+            current_app.log_exception(sys.exc_info())
 
         help_on_404 = current_app.config.get("ERROR_404_HELP", True)
         if code == 404 and help_on_404:

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -301,7 +301,10 @@ class Api(object):
         headers = {}
 
         if code >= 500:
-            current_app.log_exception(sys.exc_info())
+            exc_info = sys.exc_info()
+            if exc_info[1] is None:
+                exc_info = None
+            current_app.log_exception(exc_info)
 
         help_on_404 = current_app.config.get("ERROR_404_HELP", True)
         if code == 404 and help_on_404:


### PR DESCRIPTION
It's not always desirable to log the exception traceback and by changing this mechanism to use Flask's own ``log_exception(e)`` method, it's much easier to change this behavior.