### PR TITLE
Replace type checking using type with isinstance where possible

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -35,7 +35,7 @@ def is_indexable_but_not_string(obj):
 
 def get_value(key, obj, default=None):
     """Helper for pulling a keyed value off various types of objects"""
-    if type(key) == int:
+    if isinstance(key, int):
         return _get_value_for_key(key, obj, default)
     elif callable(key):
         return key(obj)
@@ -188,7 +188,7 @@ class List(Raw):
                         or (self.container.attribute
                             and hasattr(val, self.container.attribute)))
                         and not isinstance(self.container, Nested)
-                        and not type(self.container) is Raw
+                        and not type(self.container) is Raw 
                     else value)
             for idx, val in enumerate(value)
         ]

--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -188,7 +188,7 @@ class List(Raw):
                         or (self.container.attribute
                             and hasattr(val, self.container.attribute)))
                         and not isinstance(self.container, Nested)
-                        and not type(self.container) is Raw 
+                        and not type(self.container) is Raw
                     else value)
             for idx, val in enumerate(value)
         ]

--- a/flask_restful/inputs.py
+++ b/flask_restful/inputs.py
@@ -239,7 +239,7 @@ def boolean(value):
     already a native python boolean, and will be passed through without
     further parsing.
     """
-    if type(value) == bool:
+    if isinstance(value, bool):
         return value
 
     if not value:


### PR DESCRIPTION
Use isinstance where possible instead of type

Note: There is one scenario where running isinstance results in incorrect logic: In the file, fields.py, under class List, there is a condition check 'not type(self.container) is Raw' [line 191](https://github.com/flask-restful/flask-restful/blob/master/flask_restful/fields.py#L191). In this case using 'not isinstance(self.container, Raw' would be incorrect because 'isinstance(self.container, Raw)' returns True (because of inheritance), while 'type(self.container) is Raw' returns False