### PR TITLE
Changed how Argument.help is formatted in response

### DIFF
--- a/docs/reqparse.rst
+++ b/docs/reqparse.rst
@@ -41,7 +41,7 @@ the :attr:`flask.Request.values` dict: an integer and a string ::
 If you specify the ``help`` value, it will be rendered as the error message
 when a type error is raised while parsing it.  If you do not specify a help
 message, the default behavior is to return the message from the type error
-itself.
+itself. See :ref:`error-messages` for more details.
 
 By default, arguments are **not** required.  Also, arguments supplied in the
 request that are not part of the RequestParser will be ignored.
@@ -203,3 +203,37 @@ The application configuration key is "BUNDLE_ERRORS". For example ::
 
     ``BUNDLE_ERRORS`` is a global setting that overrides the ``bundle_errors``
     option in individual :class:`~reqparse.RequestParser` instances.
+
+
+.. _error-messages:
+Error Messages
+--------------
+
+Error messages for each field may be customized using the ``help`` parameter
+to ``Argument`` (and also ``RequestParser.add_argument``).
+
+If no help parameter is provided, the error message for the field will be
+the string representation of the type error itself. If ``help`` is provided,
+then the error message will be the value of ``help``.
+
+``help`` may include an interpolation token, ``{error_msg}``, that will be
+replaced with the string representation of the type error. This allows the
+message to be customized while preserving the original error:
+
+    from flask_restful import reqparse
+
+
+    parser = reqparse.RequestParser()
+    parser.add_argument(
+        'foo',
+        choices=('one', 'two'),
+        help='Bad choice: {error_msg}'
+    )
+
+    # If a request comes in with a value of "three" for `foo`:
+
+    {
+        "message":  {
+            "foo": "Bad choice: three is not a valid choice",
+        }
+    }

--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -54,8 +54,9 @@ class Argument(object):
         iterator. The last item listed takes precedence in the result set.
     :param choices: A container of the allowable values for the argument.
     :param help: A brief description of the argument, returned in the
-        response when the argument is invalid with the name of the argument and
-        the message passed to any exception raised by a type converter.
+        response when the argument is invalid. May optionally contain
+        an "{error_msg}" interpolation token, which will be replaced with
+        the text of the error raised by the type converter.
     :param bool case_sensitive: Whether argument values in the request are
         case sensitive or not (this will convert all values to lowercase)
     :param bool store_missing: Whether the arguments default value should
@@ -134,12 +135,12 @@ class Argument(object):
             dict with the name of the argument and the error message to be
             bundled
         """
-        help_str = '(%s) ' % self.help if self.help else ''
-        error_msg = ' '.join([help_str, str(error)]) if help_str else str(error)
+        error_str = str(error)
+        error_msg = self.help.format(error_msg=error_str) if self.help else error_str
+        msg = {self.name: "{}".format(error_msg)}
+
         if current_app.config.get("BUNDLE_ERRORS", False) or bundle_errors:
-            msg = {self.name: "%s" % (error_msg)}
             return error, msg
-        msg = {self.name: "%s" % (error_msg)}
         flask_restful.abort(400, message=msg)
 
     def parse(self, request, bundle_errors=False):

--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -135,7 +135,7 @@ class Argument(object):
             dict with the name of the argument and the error message to be
             bundled
         """
-        error_str = str(error)
+        error_str = six.text_type(error)
         error_msg = self.help.format(error_msg=error_str) if self.help else error_str
         msg = {self.name: "{0}".format(error_msg)}
 

--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -137,7 +137,7 @@ class Argument(object):
         """
         error_str = str(error)
         error_msg = self.help.format(error_msg=error_str) if self.help else error_str
-        msg = {self.name: "{}".format(error_msg)}
+        msg = {self.name: "{0}".format(error_msg)}
 
         if current_app.config.get("BUNDLE_ERRORS", False) or bundle_errors:
             return error, msg


### PR DESCRIPTION
`Argument.help` can now completely control the error message returned in the response via the `{error_msg}` interpolation token. This addresses issue #514.

See the updated docs for more details.