### PR TITLE
Fix representation being picked at random

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -33,7 +33,7 @@ def abort(http_status_code, **kwargs):
             e.data = kwargs
         raise
 
-DEFAULT_REPRESENTATIONS = {'application/json': output_json}
+DEFAULT_REPRESENTATIONS = [('application/json', output_json)]
 
 
 class Api(object):

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -75,7 +75,7 @@ class Api(object):
                  default_mediatype='application/json', decorators=None,
                  catch_all_404s=False, serve_challenge_on_401=False,
                  url_part_order='bae', errors=None):
-        self.representations = dict(DEFAULT_REPRESENTATIONS)
+        self.representations = OrderedDict(DEFAULT_REPRESENTATIONS)
         self.urls = {}
         self.prefix = prefix
         self.default_mediatype = default_mediatype
@@ -582,7 +582,7 @@ class Resource(MethodView):
         if isinstance(resp, ResponseBase):  # There may be a better way to test
             return resp
 
-        representations = self.representations or {}
+        representations = self.representations or OrderedDict()
 
         #noinspection PyUnresolvedReferences
         mediatype = request.accept_mimetypes.best_match(representations, default=None)

--- a/tests/test_accept.py
+++ b/tests/test_accept.py
@@ -5,6 +5,7 @@ from werkzeug import exceptions
 from nose.tools import assert_equals
 
 
+
 class AcceptTestCase(unittest.TestCase):
 
     def test_accept_default_application_json(self):
@@ -54,6 +55,28 @@ class AcceptTestCase(unittest.TestCase):
 
         with app.test_client() as client:
             res = client.get('/', headers=[('Accept', 'text/plain')])
+            assert_equals(res.status_code, 200)
+            assert_equals(res.content_type, 'application/json')
+
+
+    def test_accept_default_any_pick_first(self):
+
+        class Foo(flask_restful.Resource):
+            def get(self):
+                return "data"
+
+        app = Flask(__name__)
+        api = flask_restful.Api(app)
+
+        @api.representation('text/plain')
+        def text_rep(data, status_code, headers=None):
+            resp = app.make_response((str(data), status_code, headers))
+            return resp
+
+        api.add_resource(Foo, '/')
+
+        with app.test_client() as client:
+            res = client.get('/', headers=[('Accept', '*/*')])
             assert_equals(res.status_code, 200)
             assert_equals(res.content_type, 'application/json')
 
@@ -216,7 +239,3 @@ class AcceptTestCase(unittest.TestCase):
         with app.test_client() as client:
             res = client.get('/', headers=[('Accept', 'text/plain')])
             assert_equals(res.status_code, 500)
-
-
-
-


### PR DESCRIPTION
Add test for matching the any \*/\* mime type when multiple representations are active

prevent a representation to be picked at semi-random due to the unspecified order of elements in a dict

The test that I added fails with the current flask-restful master. Not every single time, but.. run the test 3/4 times and you should see the problem.