### PR TITLE
Fix typo in example

### DIFF
--- a/docs/intermediate-usage.rst
+++ b/docs/intermediate-usage.rst
@@ -120,7 +120,7 @@ exercise a larger amount of options. We'll define a resource named "User". ::
     post_parser = reqparse.RequestParser()
     post_parser.add_argument(
         'username', dest='username',
-        location='form', equired=True,
+        location='form', required=True,
         help='The user\'s username',
     )
     post_parser.add_argument(


### PR DESCRIPTION
Add missing 'r' at `required` arguement