### PR TITLE
More flexible errorhandler #2

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -8,7 +8,8 @@ from flask import make_response as original_flask_make_response
 from flask.views import MethodView
 from flask.signals import got_request_exception
 from werkzeug.datastructures import Headers
-from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound, NotAcceptable, InternalServerError
+from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound, NotAcceptable, \
+        InternalServerError, default_exceptions
 from werkzeug.http import HTTP_STATUS_CODES
 from werkzeug.wrappers import Response as ResponseBase
 from flask_restful.utils import http_status_message, unpack, OrderedDict
@@ -17,6 +18,7 @@ import sys
 from flask.helpers import _endpoint_from_view_func
 from types import MethodType
 import operator
+import six
 
 
 __all__ = ('Api', 'Resource', 'marshal', 'marshal_with', 'marshal_with_field', 'abort')
@@ -359,7 +361,7 @@ class Api(object):
 
         return resp
 
-    def errorhandler(self, exception_type):
+    def errorhandler(self, exc_class_or_code):
         """A decorator that is used to register a function for a given exception.
         Example::
 
@@ -367,11 +369,15 @@ class Api(object):
             def handle_integrity_error(exception):
                 return {'message': 'Integrity Error!'}, 500
 
-        :param exception_type: the Exception class/type to handle
-        :type exception_type: Type
+        :param exc_class_or_code: the Exception class or HTTP code
+        :type exc_class_or_code: Exception or int
         """
         def wrapper(func):
-            self.errorhandlers.append((exception_type, func))
+            if isinstance(exc_class_or_code, six.integer_types):
+                exc_class = default_exceptions[exc_class_or_code]
+            else:
+                exc_class = exc_class_or_code
+            self.errorhandlers.append((exc_class, func))
             return func
         return wrapper
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -472,7 +472,7 @@ class APITestCase(unittest.TestCase):
             self.assertEquals(resp.status_code, 503)
             self.assertEquals(resp.data.decode(), dumps({
                 'My Field': 'My Message',
-            }))
+            }) + "\n")
 
 
     def test_handle_smart_errors(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -458,22 +458,38 @@ class APITestCase(unittest.TestCase):
                 'message': BadRequest.description,
             }) + "\n")
 
-    def test_errorhandler(self):
+    def test_errorhandler_exception(self):
         app = Flask(__name__)
         api = flask_restful.Api(app)
 
-        @api.errorhandler(Mock)
+        class CustomException(Exception):
+            pass
+
+        @api.errorhandler(CustomException)
         def custom_error_response(e):
             return {"My Field": "My Message"}, 503
 
         with app.test_request_context("/foo"):
-            exception = Mock()
-            resp = api.handle_error(exception)
+            resp = api.handle_error(CustomException())
             self.assertEquals(resp.status_code, 503)
             self.assertEquals(resp.data.decode(), dumps({
                 'My Field': 'My Message',
             }) + "\n")
 
+    def test_errorhandler_code(self):
+        app = Flask(__name__)
+        api = flask_restful.Api(app)
+
+        @api.errorhandler(400)
+        def custom_error_response(e):
+            return {"message": "Custom Message"}, 400
+
+        with app.test_request_context("/foo"):
+            resp = api.handle_error(BadRequest())
+            self.assertEquals(resp.status_code, 400)
+            self.assertEquals(resp.data.decode(), dumps({
+                'message': 'Custom Message',
+            }) + "\n")
 
     def test_handle_smart_errors(self):
         app = Flask(__name__)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -458,6 +458,23 @@ class APITestCase(unittest.TestCase):
                 'message': BadRequest.description,
             }) + "\n")
 
+    def test_errorhandler(self):
+        app = Flask(__name__)
+        api = flask_restful.Api(app)
+
+        @api.errorhandler(Mock)
+        def custom_error_response(e):
+            return {"My Field": "My Message"}, 503
+
+        with app.test_request_context("/foo"):
+            exception = Mock()
+            resp = api.handle_error(exception)
+            self.assertEquals(resp.status_code, 503)
+            self.assertEquals(resp.data.decode(), dumps({
+                'My Field': 'My Message',
+            }))
+
+
     def test_handle_smart_errors(self):
         app = Flask(__name__)
         api = flask_restful.Api(app)


### PR DESCRIPTION
#### DO NOT MERGE !

This PR builds on top of #401 adding ability to specify exception by its HTTP code. Although the code is fine and tests are passing, I would like an opinion on it first.

> joshfriend:
> ..It looks like if you were to add an errorhandler to catch BadRequest, your custom resposne would be overridden by these checks.

You _can_ have your own BadRequest handler (see the test).

#### 'data' as dictionary

`handle_error` code assumes that `data` is a dictionary (`data.update(custom_data)`). This may not always be the case. For example, if you would like to have a custom error handler on non-HTTPException with `.data` attribute as string. This is a problem on existing code already.

Adding this PR would make situation much worse. User may return anything from his error handler. Current code will fall through to a series of if-code==XXX-do-this blocks which assume returned data is a dict. In other words, this PR works, but only in happy-path when User is cooperating..

#### exceptions in 'handle_error'

Exception in custom error handler will be passed down to Flask, which will fall over with..
```
  File ".../python2.7/site-packages/flask/app.py", line 1363, in handle_user_exception
    assert exc_value is e
AssertionError
```
There is NO indication what (or where) was the original exception.

We _could_ (and should) wrap call to custom error handler with try/catch-all. Thou, the problem may not in inside the handler. This code..
```
@api.errorhandler(404)
def foo1(e):
    return 'foo', 404
```
..will also generate the same `AssertionError`. The underlying problem is that default 404 handling assumes that data is a dict.

#### fall-through-ness

Processing won't stop when error handler is found. This is a source of the problems mentioned above. However, somehow the User may _depend_ on this feature. Eg. someone may want add authorization challenge on 401, even if it was already custom handled. I, personally, don't like current fall-trough. Refactoring the code would be quite a major change..

#### default handlers >=500, 404, 401, 406

> These checks will probably need to be removed and replaced with default errorhandler functions that are set up when an API object is created

I concur the idea.

However, it's not that simple (I tried :unamused:):
* currently it is possible to have both custom and default handler code executed. Not so after the change
* error handler would need to be able to indicate that it did not handle anything and the next best match should be executed:
```
def default_404_handler(self, e):
    if ERROR_404_HELP is enabled in config:
        # do dome work
        return data, 404
    else:
        # else what ? Explicit fall-through..
        return None
```
* existing code is in some cases _extending_ response created earlier..
```
data["message"] = data["message"].rstrip('.') + '. '
data['message'] += 'You have requested...'
```
After rewrite, these handlers would have no context other than the exception itself.
* 406 (NotAcceptable) handler is messing around with representation of returned data. This is not possible, if your error handler just returns (data, code, headers) tuple. That code would probably have to go to `self.make_response`

#### Summary

Either this PR is merged as it is.. making small incremental steps forward.
or 
Much bigger rewrite is needed. It should be clarified first:
* if processing should stop on first matching handler - this will change the existing semantics
* if existing `handle_error` code should be rewritten as several smaller error handlers
* what to do when exception is thrown inside error handler (may be explicit `abort(404)`)