### PR TITLE
Error handling re-worked

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -299,9 +299,16 @@ class Api(object):
 
         for typecheck, handler in self.errorhandlers:
             if isinstance(e, typecheck):
-                # unpack(None) -> (None, _, _)
-                data, code, headers = unpack(handler(e))
-                if data:
+                try:
+                    # unpack(None) -> (None, _, _)
+                    data, code, headers = unpack(handler(e))
+                    if data:
+                        break
+                except Exception:
+                    # log exception and return http 500
+                    current_app.log_exception(sys.exc_info())
+                    data, code, headers = self.default_http_exception_handler(
+                        InternalServerError('Exception in error handler!'))
                     break
         else:
             # `default_exception_handler` is always at the bottom, even if no

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -8,7 +8,8 @@ from flask import make_response as original_flask_make_response
 from flask.views import MethodView
 from flask.signals import got_request_exception
 from werkzeug.datastructures import Headers
-from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound, NotAcceptable, InternalServerError
+from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound, NotAcceptable, \
+        InternalServerError, default_exceptions
 from werkzeug.http import HTTP_STATUS_CODES
 from werkzeug.wrappers import Response as ResponseBase
 from flask_restful.utils import http_status_message, unpack, OrderedDict
@@ -17,6 +18,7 @@ import sys
 from flask.helpers import _endpoint_from_view_func
 from types import MethodType
 import operator
+import six
 
 
 __all__ = ('Api', 'Resource', 'marshal', 'marshal_with', 'marshal_with_field', 'abort')
@@ -85,6 +87,7 @@ class Api(object):
         self.serve_challenge_on_401 = serve_challenge_on_401
         self.url_part_order = url_part_order
         self.errors = errors or {}
+        self.errorhandlers = []
         self.blueprint_setup = None
         self.endpoints = set()
         self.resources = []
@@ -287,6 +290,13 @@ class Api(object):
             else:
                 raise e
 
+        for typecheck, handler in self.errorhandlers:
+            if isinstance(e, typecheck):
+                # unpack(None) -> (None, _, _)
+                data, code, headers = unpack(handler(e))
+                if data:
+                    return self.make_response(data, code, headers)
+
         headers = Headers()
         if isinstance(e, HTTPException):
             code = e.code
@@ -351,6 +361,26 @@ class Api(object):
         if code == 401:
             resp = self.unauthorized(resp)
         return resp
+
+    def errorhandler(self, exc_class_or_code):
+        """A decorator that is used to register a function for a given exception.
+        Example::
+
+            @api.errorhandler(IntegrityError)
+            def handle_integrity_error(exception):
+                return {'message': 'Integrity Error!'}, 500
+
+        :param exc_class_or_code: the Exception class or HTTP code
+        :type exc_class_or_code: Exception or int
+        """
+        def wrapper(func):
+            if isinstance(exc_class_or_code, six.integer_types):
+                exc_class = default_exceptions[exc_class_or_code]
+            else:
+                exc_class = exc_class_or_code
+            self.errorhandlers.insert(0, (exc_class, func))
+            return func
+        return wrapper
 
     def mediatypes_method(self):
         """Return a method that returns a list of mediatypes

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -49,31 +49,26 @@ class APITestCase(unittest.TestCase):
     def test_unauthorized_no_challenge_by_default(self):
         app = Flask(__name__)
         api = flask_restful.Api(app)
-        response = Mock()
-        response.headers = {}
         with app.test_request_context('/foo'):
-            response = api.unauthorized(response)
-        assert_false('WWW-Authenticate' in response.headers)
+            data, code, headers = unpack(api.unauthorized(Unauthorized()))
+        # error handler not triggered
+        self.assertEquals(data, None)
 
     def test_unauthorized(self):
         app = Flask(__name__)
         api = flask_restful.Api(app, serve_challenge_on_401=True)
-        response = Mock()
-        response.headers = {}
         with app.test_request_context('/foo'):
-            response = api.unauthorized(response)
-        self.assertEquals(response.headers['WWW-Authenticate'],
+            data, code, headers = unpack(api.unauthorized(Unauthorized()))
+        self.assertEquals(headers['WWW-Authenticate'],
                           'Basic realm="flask-restful"')
 
     def test_unauthorized_custom_realm(self):
         app = Flask(__name__)
         app.config['HTTP_BASIC_AUTH_REALM'] = 'Foo'
         api = flask_restful.Api(app, serve_challenge_on_401=True)
-        response = Mock()
-        response.headers = {}
         with app.test_request_context('/foo'):
-            response = api.unauthorized(response)
-        self.assertEquals(response.headers['WWW-Authenticate'], 'Basic realm="Foo"')
+            data, code, headers = unpack(api.unauthorized(Unauthorized()))
+        self.assertEquals(headers['WWW-Authenticate'], 'Basic realm="Foo"')
 
     def test_handle_error_401_no_challenge_by_default(self):
         app = Flask(__name__)
@@ -87,8 +82,7 @@ class APITestCase(unittest.TestCase):
     def test_handle_error_401_sends_challege_default_realm(self):
         app = Flask(__name__)
         api = flask_restful.Api(app, serve_challenge_on_401=True)
-        exception = HTTPException()
-        exception.code = 401
+        exception = Unauthorized()
         exception.data = {'foo': 'bar'}
 
         with app.test_request_context('/foo'):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -458,6 +458,39 @@ class APITestCase(unittest.TestCase):
                 'message': BadRequest.description,
             }) + "\n")
 
+    def test_errorhandler_exception(self):
+        app = Flask(__name__)
+        api = flask_restful.Api(app)
+
+        class CustomException(Exception):
+            pass
+
+        @api.errorhandler(CustomException)
+        def custom_error_response(e):
+            return {"My Field": "My Message"}, 503
+
+        with app.test_request_context("/foo"):
+            resp = api.handle_error(CustomException())
+            self.assertEquals(resp.status_code, 503)
+            self.assertEquals(resp.data.decode(), dumps({
+                'My Field': 'My Message',
+            }) + "\n")
+
+    def test_errorhandler_code(self):
+        app = Flask(__name__)
+        api = flask_restful.Api(app)
+
+        @api.errorhandler(400)
+        def custom_error_response(e):
+            return {"message": "Custom Message"}, 400
+
+        with app.test_request_context("/foo"):
+            resp = api.handle_error(BadRequest())
+            self.assertEquals(resp.status_code, 400)
+            self.assertEquals(resp.data.decode(), dumps({
+                'message': 'Custom Message',
+            }) + "\n")
+
     def test_handle_smart_errors(self):
         app = Flask(__name__)
         api = flask_restful.Api(app)


### PR DESCRIPTION
Hi,

Refer first to #541 for my comments on current issues, if you haven't read it already.

Basically, in this PR I have addressed them as I've seen fit, taking a great liberty of hacking existing code.
#### Summary
- error handler framework implemented which execute custom handlers until a matching handler is found
- handler is installed either by `register_error_handler` method or `error_handler` decorator
- handler may indicate by returning None that processing should continue to next candidate
- first match wins, even if better match was there (subclass is better than base exception class)
- handlers are processed in _reverse_ order they were registered (or decorated). So, user may override any Flask-Restful default handlers as his handler will be registered later, closer to the top.
- existing code in `handle_error` has been re-written in form of error handlers

I didn't get any feedback on these topics, so I decided for myself..

> Much bigger rewrite is needed. It should be clarified first:
> 
> if processing should stop on first matching handler - this will change the existing semantics

It does stop on first error handler which return non-None.

> if existing handle_error code should be rewritten as several smaller error handlers

Yes. Old if-code==XX-then were rewritten as error handlers and they are installed by default.

> what to do when exception is thrown inside error handler (may be explicit abort(404))

Exception is logged and http 500 is returned to client. No further processing is done.
#### Notes
- although all tests are green, I'm not 100% sure that nothing was broken. Actually, I'm aware that in some cases new code returns slightly different response that old one. This is due to the fact that handlers are context-free and they cannot pass data from one to the other.
- I took `self.unauthorized` method and changed its signature to match error handler (and updated all tests referring that method). I'm not aware if `unauthorized` was used somewhere else except 401 handling. If yes, than new error handler should be created and this one left for compatibility.
- I had to update one test to make it pass. Old code was catching all HTTPExceptions with code 401. New code is handling only Unauthorized (subclass of HTTPException with code 401).
- handling of 406 could not be done as error handler (handler cannot affect final representation of data). That code had to be moved to `make_response`
- Bunch of new methods were created. As they are all visible as API, I would be more than happy to rename them to follow any project naming conventions / personal preferences / etc.
- Sphinx documentation should be written. But I won't invest my time before this PR is at least informally approved
