### PR TITLE
Backwards-compatible change to globally configure strict request parsing

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -282,12 +282,21 @@ class RequestParser(object):
 
         return self
 
-    def parse_args(self, req=None, strict=False):
+    def parse_args(self, req=None, strict=None):
         """Parse all arguments from the provided request and return the results
         as a Namespace
 
         :param strict: if req includes args not in parser, throw 400 BadRequest exception
         """
+        if strict is None:
+            try:
+                strict = current_app.config.get('REQPARSE_STRICT', False)
+            except RuntimeError as e:
+                if str(e) == 'working outside of application context':
+                    strict = False
+                else:
+                    raise e
+
         if req is None:
             req = request
 

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -801,6 +801,40 @@ class ReqParseTestCase(unittest.TestCase):
         parser.add_argument('foo', type=int)
         self.assertRaises(exceptions.BadRequest, parser.parse_args, req, strict=True)
 
+    def test_strict_parsing_configured_off(self):
+        app = Flask(__name__)
+        app.config['REQPARSE_STRICT'] = False
+        with app.app_context():
+            req = Request.from_values("/bubble?foo=baz")
+            parser = RequestParser()
+            args = parser.parse_args(req)
+            self.assertEquals(args, {})
+
+    def test_strict_parsing_configured_on(self):
+        app = Flask(__name__)
+        app.config['REQPARSE_STRICT'] = True
+        with app.app_context():
+            req = Request.from_values("/bubble?foo=baz")
+            parser = RequestParser()
+            self.assertRaises(exceptions.BadRequest, parser.parse_args, req)
+
+    def test_strict_parsing_configured_off_overridden(self):
+        app = Flask(__name__)
+        app.config['REQPARSE_STRICT'] = False
+        with app.app_context():
+            req = Request.from_values("/bubble?foo=baz")
+            parser = RequestParser()
+            self.assertRaises(exceptions.BadRequest, parser.parse_args, req, strict=True)
+
+    def test_strict_parsing_configured_on_overridden(self):
+        app = Flask(__name__)
+        app.config['REQPARSE_STRICT'] = True
+        with app.app_context():
+            req = Request.from_values("/bubble?foo=baz")
+            parser = RequestParser()
+            args = parser.parse_args(req, strict=False)
+            self.assertEquals(args, {})
+
     def test_trim_argument(self):
         req = Request.from_values("/bubble?foo= 1 &bar=bees&n=22")
         parser = RequestParser()


### PR DESCRIPTION
Motivation:
    This change supports a Flask app that will impose strict parsing globally.
    Although it's possible to put `strict=True` on every call to `.parse_args`,
    there is the inherent risk of forgetting to put `strict=True` on one of the
    calls.  The 'REQPARSE_STRICT' app config removes this risk.