### PR TITLE
Added option iso8601_sep when formatting DateTime fields

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -349,17 +349,21 @@ class DateTime(Raw):
 
     :param dt_format: ``'rfc822'`` or ``'iso8601'``
     :type dt_format: str
+    :param iso8601_sep: A one-character separator, placed between the date
+        and time portions of the result if ``dt_format`` is ``'iso8601'``
+    :type iso8601_sep: str
     """
-    def __init__(self, dt_format='rfc822', **kwargs):
+    def __init__(self, dt_format='rfc822', iso8601_sep='T', **kwargs):
         super(DateTime, self).__init__(**kwargs)
         self.dt_format = dt_format
+        self.iso8601_sep = iso8601_sep
 
     def format(self, value):
         try:
             if self.dt_format == 'rfc822':
                 return _rfc822(value)
             elif self.dt_format == 'iso8601':
-                return _iso8601(value)
+                return _iso8601(value,self.iso8601_sep)
             else:
                 raise MarshallingException(
                     'Unsupported date format %s' % self.dt_format
@@ -403,7 +407,7 @@ def _rfc822(dt):
     return formatdate(timegm(dt.utctimetuple()))
 
 
-def _iso8601(dt):
+def _iso8601(dt, sep='T'):
     """Turn a datetime object into an ISO8601 formatted date.
 
     Example::
@@ -412,6 +416,9 @@ def _iso8601(dt):
 
     :param dt: The datetime to transform
     :type dt: datetime
+    :param sep: A one-character separator, placed between the date and time
+        portions of the result
+    :type sep: str
     :return: A ISO 8601 formatted date string
     """
-    return dt.isoformat()
+    return dt.isoformat(sep)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -370,6 +370,11 @@ class FieldsTestCase(unittest.TestCase):
         field = fields.DateTime(dt_format='iso8601')
         self.assertEquals("2011-08-22T20:58:45+01:00", field.output("bar", obj))
 
+    def test_iso8601_date_field_with_sep(self):
+        obj = {"bar": datetime(2011, 8, 22, 20, 58, 45)}
+        field = fields.DateTime(dt_format='iso8601', iso8601_sep=' ')
+        self.assertEquals("2011-08-22 20:58:45", field.output("bar", obj))
+
     def test_unsupported_datetime_format(self):
         obj = {"bar": datetime(2011, 8, 22, 20, 58, 45)}
         field = fields.DateTime(dt_format='raw')


### PR DESCRIPTION
I had a need to control the format of the ISO8601 DateTime string that is returned. The datetime.isoformat() function allows a separator character to be passed in when calling it, so I've added this functionality to this library.