### PR TITLE
Support Flask's TRAP_BAD_REQUEST_ERRORS config flag

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -8,7 +8,7 @@ from flask import make_response as original_flask_make_response
 from flask.views import MethodView
 from flask.signals import got_request_exception
 from werkzeug.datastructures import Headers
-from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound, NotAcceptable, InternalServerError
+from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound, NotAcceptable, InternalServerError, BadRequestKeyError
 from werkzeug.http import HTTP_STATUS_CODES
 from werkzeug.wrappers import Response as ResponseBase
 from flask_restful.utils import http_status_message, unpack, OrderedDict
@@ -286,6 +286,9 @@ class Api(object):
                 raise
             else:
                 raise e
+
+        if isinstance(e, BadRequestKeyError) and current_app.propagate_exceptions:
+            raise e
 
         headers = Headers()
         if isinstance(e, HTTPException):


### PR DESCRIPTION
When setting the TRAP_BAD_REQUEST_ERRORS config option is turned
on, HTTP requests that fail with a BadRequestKeyError exception
should be treated like normal exceptions.