### PR TITLE
new Argument.help supports unicode error messages

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -143,7 +143,7 @@ class Argument(object):
         """
         error_str = six.text_type(error)
         error_msg = self.help.format(error_msg=error_str) if self.help else error_str
-        msg = {self.name: "{0}".format(error_msg)}
+        msg = {self.name: u"{0}".format(error_msg)}
 
         if current_app.config.get("BUNDLE_ERRORS", False) or bundle_errors:
             return error, msg

--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -143,7 +143,7 @@ class Argument(object):
         """
         error_str = six.text_type(error)
         error_msg = self.help.format(error_msg=error_str) if self.help else error_str
-        msg = {self.name: u"{0}".format(error_msg)}
+        msg = {self.name: error_msg}
 
         if current_app.config.get("BUNDLE_ERRORS", False) or bundle_errors:
             return error, msg

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -30,6 +30,19 @@ class ReqParseTestCase(unittest.TestCase):
             abort.assert_called_with(400, message=expected)
 
     @patch('flask_restful.abort')
+    def test_help_with_unicode_error_msg(self, abort):
+        app = Flask(__name__)
+        with app.app_context():
+            parser = RequestParser()
+            parser.add_argument('foo', choices=('one', 'two'), help=u'Bad choice: {error_msg}')
+            req = Mock(['values'])
+            req.values = MultiDict([('foo', u'\xf0\x9f\x8d\x95')])
+            parser.parse_args(req)
+            expected = {'foo': u'Bad choice: \xf0\x9f\x8d\x95 is not a valid choice'}
+            abort.assert_called_with(400, message=expected)
+
+
+    @patch('flask_restful.abort')
     def test_help_no_error_msg(self, abort):
         app = Flask(__name__)
         with app.app_context():


### PR DESCRIPTION
addresses bug in #508 

here the problematic code:

       error_str = six.text_type(error)
       error_msg = self.help.format(error_msg=error_str) if self.help else error_str
       msg = {self.name: "{0}".format(error_msg)}

six.text_type is unicode in python 2.x

`>>> six.text_type`
`>>> <type 'unicode'>`


The help string should be unicode if you rely on the new error message formatting, and you expect to send unicode strings

`error_msg = self.help.format(error_msg=error_str) if self.help else error_str`

The message was coerced into byte string, no matter if the actual error is unicode.

`msg = {self.name: u"{0}".format(error_msg)}`