### PR TITLE
Add description of methods argument to add_resource docs

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -138,6 +138,11 @@ You can also match parts of the path as variables to your resource methods. ::
     api.add_resource(Todo,
         '/todo/<int:todo_id>', endpoint='todo_ep')
 
+You can limit which HTTP methods your API exposes by adding the methods argument. ::
+
+    api.add_resource(Todo,
+        '/todo/<int:todo_id>', endpoint='todo_ep', methods=['GET', 'PUT'])
+
 .. note ::
 
     If a request does not match any of your application's endpoints,

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -396,6 +396,7 @@ class Api(object):
             api.add_resource(HelloWorld, '/', '/hello')
             api.add_resource(Foo, '/foo', endpoint="foo")
             api.add_resource(FooSpecial, '/special/foo', endpoint="foo")
+            api.add_resource(FooGetPutOnly, '/foo/<string:foo_id>, endpoint='foogp', methods=['GET', 'PUT'])
 
         """
         if self.app is not None:

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -396,7 +396,7 @@ class Api(object):
             api.add_resource(HelloWorld, '/', '/hello')
             api.add_resource(Foo, '/foo', endpoint="foo")
             api.add_resource(FooSpecial, '/special/foo', endpoint="foo")
-            api.add_resource(FooGetPutOnly, '/foo/<string:foo_id>, endpoint='foogp', methods=['GET', 'PUT'])
+            api.add_resource(FooGetPutOnly, '/foo/<string:foo_id>', endpoint='foogp', methods=['GET', 'PUT'])
 
         """
         if self.app is not None:


### PR DESCRIPTION
I've added a description of using the methods argument on the add_resource docs, as this extremely useful feature is not obvious, currently.

I'm autogenating my API docs so needed to limit some HTTP methods, and this argument was a real life saver.  So thought I'd try to save others from digging through the source and stack-overflow :) 