### PR TITLE
typo: and -> or

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -578,7 +578,7 @@ class Resource(MethodView):
         # Taken from flask
         #noinspection PyUnresolvedReferences
         meth = getattr(self, request.method.lower(), None)
-        if meth is None and request.method == 'HEAD':
+        if meth is None or request.method == 'HEAD':
             meth = getattr(self, 'get', None)
         assert meth is not None, 'Unimplemented method %r' % request.method
 


### PR DESCRIPTION
from http://flask.pocoo.org/docs/0.10/api/#flask.Flask.add_url_rule:

    options – the options to be forwarded to the underlying Rule object. A change to Werkzeug
    is handling of method options. methods is a list of methods this rule should be limited to 
    (GET, POST etc.). By default a rule just listens for GET (and implicitly HEAD). Starting 
    with Flask 0.6, OPTIONS is implicitly added and handled by the standard request handling.

I believe there is a typo in line 581 as there is no way (to my knowledge) meth (which is actualy request.method.lower()) could be None AND request.method could be 'HEAD' at the same time. Because of that, I strongly believe **and** should actually be **or**.