### PR TITLE
use default representations for Resource

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -570,7 +570,7 @@ class Resource(MethodView):
     from the url rule used when adding the resource to an Api instance. See
     :meth:`~flask_restful.Api.add_resource` for details.
     """
-    representations = None
+    representations = OrderedDict(DEFAULT_REPRESENTATIONS)
     method_decorators = []
 
     def dispatch_request(self, *args, **kwargs):


### PR DESCRIPTION
I think flask-restful can use two method:

```
from flask import Flask
from flask.views import MethodView
from flask_restful import Api

app = Flask(__name__)
api = Api(app)

class UploadFile(MethodView):
    def get(self):
        return 0

api.add_resource(UploadFile, '/', endpoint='index')
```
and 

```
from flask import Flask
from flask_restful import Resource

app = Flask(__name__)

class UploadFile(Resource):
    def get(self):
        return 0

app.add_url_rule('/', view_func=UploadFile.as_view('index')) 
```

But now. The second method not works. 
