### PR TITLE
__init__.py update for Api class docs string to support Blueprints

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -50,6 +50,7 @@ class Api(object):
 
     :param app: the Flask application object
     :type app: flask.Flask
+    :type app: flask.Blueprint
     :param prefix: Prefix all routes with a value, eg v1 or 2010-04-01
     :type prefix: str
     :param default_mediatype: The default media type to return


### PR DESCRIPTION
As Blueprints are supported for flask-restful api creation, adding blueprint to ':type' in doc string
