### PR TITLE
Register Restful Api instance in app.extensions

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -118,6 +118,9 @@ class Api(object):
             self._init_app(app)
         else:
             self.blueprint = app
+        if not hasattr(app, 'extensions'):
+            app.extensions = {}
+        app.extensions['Restful'] = self
 
     def _complete_url(self, url_part, registration_prefix):
         """This method is used to defer the construction of the final url in


### PR DESCRIPTION
It is a common practice to register the extensions in app.extensions.
This will allow to get access to the Api instance from current_app.