### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ Flask-RESTful provides the building blocks for creating a great REST API.
 
 ## User Guide
 
-You'll find the user guide and all documentation [here](http://flask-restful.readthedocs.org/en/latest/)
+You'll find the user guide and all documentation [here](https://flask-restful.readthedocs.io/en/latest/)
 

--- a/docs/reqparse.rst
+++ b/docs/reqparse.rst
@@ -8,7 +8,7 @@ Request Parsing
     The whole request parser part of Flask-RESTful is slated for removal and
     will be replaced by documentation on how to integrate with other packages
     that do the input/output stuff better
-    (such as `marshmallow <http://marshmallow.readthedocs.org>`_).
+    (such as `marshmallow <https://marshmallow.readthedocs.io>`_).
     This means that it will be maintained until 2.0 but consider it deprecated.
     Don't worry, if you have code using that now and wish to continue doing so,
     it's not going to go away any time too soon.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.