### PR TITLE
Add param **values like Flask's url_for to fields.Url

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -293,16 +293,20 @@ class Url(Raw):
     :type absolute: bool
     :param scheme: URL scheme specifier (e.g. ``http``, ``https``)
     :type scheme: str
+    :param values: the variable arguments of the URL rule
     """
-    def __init__(self, endpoint=None, absolute=False, scheme=None):
+    def __init__(self, endpoint=None, absolute=False, scheme=None, **values):
         super(Url, self).__init__()
         self.endpoint = endpoint
         self.absolute = absolute
         self.scheme = scheme
+        self.values = values
 
     def output(self, key, obj):
         try:
             data = to_marshallable_type(obj)
+            if data is not None:
+                data.update(self.values)
             endpoint = self.endpoint if self.endpoint is not None else request.endpoint
             o = urlparse(url_for(endpoint, _external=self.absolute, **data))
             if self.absolute:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -280,6 +280,93 @@ class FieldsTestCase(unittest.TestCase):
         with app.test_request_context("/foo/hey", base_url="http://localhost"):
             self.assertEquals("https://localhost/foo/3", field.output("hey", Foo()))
 
+    def test_url_values(self):
+        app = Flask(__name__)
+        app.add_url_rule("/<hey>/<name>", "foobar", view_func=lambda x: x)
+        field = fields.Url("foobar", name='felipe')
+
+        with app.test_request_context("/"):
+            self.assertEquals("/3/felipe", field.output("hey", Foo()))
+
+    def test_url_values_invalid_object(self):
+        app = Flask(__name__)
+        app.add_url_rule("/<hey>/<name>", "foobar", view_func=lambda x: x)
+        field = fields.Url(name='felipe')
+
+        with app.test_request_context("/hey/name"):
+            self.assertRaises(MarshallingException, lambda: field.output("hey", None))
+
+    def test_url_absolute_values(self):
+        app = Flask(__name__)
+        app.add_url_rule("/<hey>/<name>", "foobar", view_func=lambda x: x)
+        field = fields.Url("foobar", absolute=True, name='felipe')
+
+        with app.test_request_context("/"):
+            self.assertEquals("http://localhost/3/felipe", field.output("hey", Foo()))
+
+    def test_url_absolute_scheme_values(self):
+        """Url.scheme should override current_request.scheme"""
+        app = Flask(__name__)
+        app.add_url_rule("/<hey>/<name>", "foobar", view_func=lambda x: x)
+        field = fields.Url("foobar", absolute=True, scheme='https', name='felipe')
+
+        with app.test_request_context("/", base_url="http://localhost"):
+            self.assertEquals("https://localhost/3/felipe", field.output("hey", Foo()))
+
+    def test_url_without_endpoint_values(self):
+        app = Flask(__name__)
+        app.add_url_rule("/<hey>/<name>", "foobar", view_func=lambda x: x)
+        field = fields.Url(name='felipe')
+
+        with app.test_request_context("/hey/name"):
+            self.assertEquals("/3/felipe", field.output("hey", Foo()))
+
+    def test_url_without_endpoint_absolute_values(self):
+        app = Flask(__name__)
+        app.add_url_rule("/<hey>/<name>", "foobar", view_func=lambda x: x)
+        field = fields.Url(absolute=True, name='felipe')
+
+        with app.test_request_context("/hey/name"):
+            self.assertEquals("http://localhost/3/felipe", field.output("hey", Foo()))
+
+    def test_url_without_endpoint_absolute_scheme_values(self):
+        app = Flask(__name__)
+        app.add_url_rule("/<hey>/<name>", "foobar", view_func=lambda x: x)
+        field = fields.Url(absolute=True, scheme='https', name='felipe')
+
+        with app.test_request_context("/hey/name", base_url="http://localhost"):
+            self.assertEquals("https://localhost/3/felipe", field.output("hey", Foo()))
+
+    def test_url_with_blueprint_values(self):
+        app = Flask(__name__)
+        bp = Blueprint("foo", __name__, url_prefix="/foo")
+        bp.add_url_rule("/<hey>/<name>", "foobar", view_func=lambda x: x)
+        app.register_blueprint(bp)
+        field = fields.Url(name='felipe')
+
+        with app.test_request_context("/foo/hey/name"):
+            self.assertEquals("/foo/3/felipe", field.output("hey", Foo()))
+
+    def test_url_with_blueprint_absolute_values(self):
+        app = Flask(__name__)
+        bp = Blueprint("foo", __name__, url_prefix="/foo")
+        bp.add_url_rule("/<hey>/<name>", "foobar", view_func=lambda x: x)
+        app.register_blueprint(bp)
+        field = fields.Url(absolute=True, name='felipe')
+
+        with app.test_request_context("/foo/hey/name"):
+            self.assertEquals("http://localhost/foo/3/felipe", field.output("hey", Foo()))
+
+    def test_url_with_blueprint_absolute_scheme_values(self):
+        app = Flask(__name__)
+        bp = Blueprint("foo", __name__, url_prefix="/foo")
+        bp.add_url_rule("/<hey>/<name>", "foobar", view_func=lambda x: x)
+        app.register_blueprint(bp)
+        field = fields.Url(absolute=True, scheme='https', name='felipe')
+
+        with app.test_request_context("/foo/hey/name", base_url="http://localhost"):
+            self.assertEquals("https://localhost/foo/3/felipe", field.output("hey", Foo()))
+
     def test_int(self):
         field = fields.Integer()
         self.assertEquals(3, field.output("hey", {'hey': 3}))


### PR DESCRIPTION
Hey,

I've worked with this awesome framework, but I cannot create a simple output like:

```json
"log": {
  "_links": {
    "self": "/api/v1/company/5/log/2016/6/5"
  }
}
```

... because my object Log does not have attributes like year, month and day.

Since `url_for` from Flask accepts `**values`, why not accept it on output fields? So I just add it.

Now I can:

```python
log_fields = {
  '_links': {'self': fields.Url(year=2016, month=6, day=5)}
}
```

Regards :smiley: 

