### PR TITLE
Single Resource Instance per Endpoint

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -46,6 +46,7 @@ A huge thanks to all of our contributors:
 - Jeff Widman
 - Joakim Ekberg
 - Johannes
+- John Richter
 - Jordan Yelloz
 - Josh Friend
 - Joshua C. Randall

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -602,6 +602,38 @@ class Resource(MethodView):
 
         return resp
 
+    @classmethod
+    def as_view(cls, name, *class_args, **class_kwargs):
+        """Converts the class into an actual view function that can be used with the routing
+        system. Internally this instantiates a new :class:`Resource` and generates a function on
+        the fly which uses the resource to properly route requests via the :meth:`dispatch_request`
+        method.
+
+        The arguments passed to :meth:`as_view` are forwarded to the
+        constructor of the class.
+        """
+        resource = cls(*class_args, **class_kwargs)
+
+        def view(*args, **kwargs):
+            return resource.dispatch_request(*args, **kwargs)
+
+        if cls.decorators:
+            view.__name__ = name
+            view.__module__ = cls.__module__
+            for decorator in cls.decorators:
+                view = decorator(view)
+
+        # We attach the view class to the view function for two reasons:
+        # first of all it allows us to easily figure out what class-based
+        # view this thing came from, secondly it's also used for instantiating
+        # the view class so you can actually replace it with something else
+        # for testing purposes and debugging.
+        view.view_class = cls
+        view.__name__ = name
+        view.__doc__ = cls.__doc__
+        view.__module__ = cls.__module__
+        view.methods = cls.methods
+        return view
 
 def marshal(data, fields, envelope=None):
     """Takes raw data (in the form of a dict, list, object) and a dict of

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ version_file = path.join(
     'flask_restful',
     '__version__.py'
 )
-with open(version_file, 'rb') as fp:
+with open(version_file, 'r') as fp:
     m = re.search(
         r"^__version__ = ['\"]([^'\"]*)['\"]",
         fp.read(),

--- a/tests/test_api_with_blueprint.py
+++ b/tests/test_api_with_blueprint.py
@@ -120,8 +120,8 @@ class APIWithBlueprintTestCase(unittest.TestCase):
     def test_error_routing(self):
         blueprint = Blueprint('test', __name__)
         api = flask_restful.Api(blueprint)
-        api.add_resource(HelloWorld(), '/hi', endpoint="hello")
-        api.add_resource(GoodbyeWorld(404), '/bye', endpoint="bye")
+        api.add_resource(HelloWorld, '/hi', endpoint="hello")
+        api.add_resource(GoodbyeWorld, '/bye', endpoint="bye", resource_class_args=(404,))
         app = Flask(__name__)
         app.register_blueprint(blueprint)
         with app.test_request_context('/hi', method='POST'):
@@ -134,13 +134,13 @@ class APIWithBlueprintTestCase(unittest.TestCase):
     def test_non_blueprint_rest_error_routing(self):
         blueprint = Blueprint('test', __name__)
         api = flask_restful.Api(blueprint)
-        api.add_resource(HelloWorld(), '/hi', endpoint="hello")
-        api.add_resource(GoodbyeWorld(404), '/bye', endpoint="bye")
+        api.add_resource(HelloWorld, '/hi', endpoint="hello")
+        api.add_resource(GoodbyeWorld, '/bye', endpoint="bye", resource_class_args=(404,))
         app = Flask(__name__)
         app.register_blueprint(blueprint, url_prefix='/blueprint')
         api2 = flask_restful.Api(app)
-        api2.add_resource(HelloWorld(), '/hi', endpoint="hello")
-        api2.add_resource(GoodbyeWorld(404), '/bye', endpoint="bye")
+        api2.add_resource(HelloWorld, '/hi', endpoint="hello")
+        api2.add_resource(GoodbyeWorld, '/bye', endpoint="bye", resource_class_args=(404,))
         with app.test_request_context('/hi', method='POST'):
             assert_false(api._should_use_fr_error_handler())
             assert_true(api2._should_use_fr_error_handler())
@@ -163,8 +163,8 @@ class APIWithBlueprintTestCase(unittest.TestCase):
     def test_non_blueprint_non_rest_error_routing(self):
         blueprint = Blueprint('test', __name__)
         api = flask_restful.Api(blueprint)
-        api.add_resource(HelloWorld(), '/hi', endpoint="hello")
-        api.add_resource(GoodbyeWorld(404), '/bye', endpoint="bye")
+        api.add_resource(HelloWorld, '/hi', endpoint="hello")
+        api.add_resource(GoodbyeWorld, '/bye', endpoint="bye", resource_class_args=(404,))
         app = Flask(__name__)
         app.register_blueprint(blueprint, url_prefix='/blueprint')
 


### PR DESCRIPTION
Greetings!  I ran across a performance issue while using Flask-Restful this week and I'd like to submit this PR as a resolution.

## Problem

Flask's pluggable views are only containers for collections of view functions.  For every request that the app receives, Flask instantiates a new instance of the container and routes the request using `MethodView.dispatch_request()`.  Flask-Restful's `App.Resource` customizes `dispatch_request`, but does not customize the inherited `View.as_view()` method which performs the instantiation and request routing.  

For larger, more complex apps it makes sense to create an API to expose and manage underlying data; this is also a fundamental goal of this project.  As complexity increases, there is a desire to track state between requests, add specialized data access objects, add clients for remote services, and more.  The current request flow does not allow state to be tracked within a `Resource` and suffers from the performance overhead of instantiation per request.

## Solution

Using a modified `View.as_view` class method, instantiate the `Resource` once outside of the returned view function and leverage the closure of the instance inside the returned `view` function.  This does not require any changes to `_register_view` and does not break compatibility with non-`Resource` views. The code was taken from `Flask.views.View.as_view`.

## Performance Tests

Using [siege](https://github.com/JoeDog/siege), I simulated 10 parallel requests over 60 seconds to a varying range of `Resource` complexities, simple - complex.

3.4Ghz Intel i5 4670K, 16 GB RAM, OS X 10.11.5

### Simple

```python
class SimpleResource(Resource):
    def __init__(self):
        super(SimpleResource, self).__init__()
        self.simple = 'simple'
    def get(self):
        return 'GET'

app = flask.Flask(__name__)
api = Api(app)
api.add_resource(Index, '/')
app.run()
```

`❯ python my_app.py`
`❯ siege -c 10 -t 60S http://localhost:5000/`

Metric | 0.3.5 | My Solution
------ | ----- | -------------
Transactions | 2334 | 2373
Availability | 100.00% | 100.00%
Elapsed Time | 59.05 s | 59.19
Data Transferred | 0.01 MB | 0.01 MB
Response Time | 0.00 secs | 0.00 s
Transaction Rate | 39.53/sec | 40.09/sec
Throughput | 0.00 MB/sec | 0.00 MB/sec
Concurrency | 0.05 | 0.06
Successful Transactions | 2334 | 2373
Failed Transactions | 0 | 0
Longest Transaction | 0.01 s | 0.01 s
Shortest Transaction | 0.00 s | 0.01 s

### Moderate-ish

```python
class ModerateResource(Resource):
    def __init__(self):
        super(ModerateResource, self).__init__()
        self.moderate = 'moderate' * 1000000
    def get(self):
        return 'GET'

app = flask.Flask(__name__)
api = Api(app)
api.add_resource(Index, '/')
app.run()
```

`❯ python my_app.py`
`❯ siege -c 10 -t 60S http://localhost:5000/`

Metric | 0.3.5 | My Solution
------ | ----- | -------------
Transactions | 2360 | 2395
Availability | 100.00% | 100.00%
Elapsed Time | 59.27 s | 59.66 s
Data Transferred | 0.01 MB | 0.01 MB
Response Time | 0.00 s | 0.00 s
Transaction Rate | 39.82/sec | 40.14/sec
Throughput | 0.00 MB/sec | 0.00 MB/sec
Concurrency | 0.04 | 0.05
Successful Transactions | 2360 | 2395
Failed Transactions | 0 | 0
Longest Transaction | 0.03 s | 0.01 s
Shortest Transaction | 0.00 s | 0.00 s

### Complex

```python
class ComplexResource(Resource):
    def __init__(self):
        super(ComplexResource, self).__init__()
        self.complex = self.fib(30)
    def fib(self, num):
        if 0 <= num <= 1: return 1
        return self.fib(num - 1) + self.fib(num - 2)
    def get(self):
        return 'GET'

app = flask.Flask(__name__)
api = Api(app)
api.add_resource(Index, '/')
app.run()
```

`❯ python my_app.py`
`❯ siege -c 10 -t 60S http://localhost:5000/`

Metric | 0.3.5 | My Solution
------ | ----- | -------------
Transactions | 128 | 2353
Availability | 100.00% | 100.00%
Elapsed Time | 59.77 s | 59.14 s
Data Transferred | 0.00 MB | 0.01 MB
Response Time | 4.28 s | 0.00 s
Transaction Rate | 2.14/sec | 39.79/sec
Throughput | 0.00 MB/sec | 0.00 MB/sec
Concurrency | 9.16 | 0.06
Successful Transactions | 128 | 2353
Failed Transactions | 0 | 0
Longest Transaction | 4.93 s | 0.01 s
Shortest Transaction | 0.47 | 0.00 s

### Complex with 7 Gunicorn Workers (8 total CPU cores)

```python
class ComplexResource(Resource):
    def __init__(self):
        super(ComplexResource, self).__init__()
        self.complex = self.fib(30)
    def fib(self, num):
        if 0 <= num <= 1: return 1
        return self.fib(num - 1) + self.fib(num - 2)
    def get(self):
        return 'GET'

app = flask.Flask(__name__)
api = Api(app)
api.add_resource(Index, '/')
```

`❯ gunicorn --workers=7 my_app:app`
`❯ siege -c 10 -t 60S http://localhost:5000/`

Metric | 0.3.5 | My Solution
------ | ----- | -------------
Transactions | 460 | 2280
Availability | 100.00% | 100.00 %
Elapsed Time | 59.31 s | 59.02 s
Data Transferred | 0.00 MB | 0.01 MB
Response Time | 1.03 s | 0.00 s
Transaction Rate | 7.76/sec | 38.63
Throughput | 0.00 MB/sec | 0.00 MB/sec
Concurrency | 8.00 | 0.05
Successful Transactions | 460 | 2280
Failed Transactions | 0 | 0
Longest Transaction | 1.72 s | 0.01 s
Shortest Transaction | 0.77 s | 0.00 s

## Conclusion

Even when using Gunicorn to horizontally scale the app, the current behavior results in transitions times ~77 times slower in the best case and ~172 times slower in the worst case. The proposed solution equates to a 5x increase transaction speed (at minimum!) in these tests which will translate to real world web API response time decreases and transaction throughput increases as well as add the flexibility that stateful `Resources` will bring to Flask-Restful API endpoint implementations.

In the simple case, we can show that marginal performance increases are achieved by eliminating class instantiation for each request.

[Travis CI Test Results](https://travis-ci.org/johnrichter/flask-restful/branches)