### PR TITLE
Add python 3.5 and 3.6 support to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, py35
+envlist = py26, py27, py33, py34, py35, py36
 
 [testenv]
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27, py33, py34, py35
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
Added latest stable version of python (3.5) to the tox file, confirmed all tests pass on this version. Also added py36, even though it isn't available yet in Travis.