### PR TITLE
Fix reqparse (action='append' and location='json')

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -1,4 +1,6 @@
 from copy import deepcopy
+
+import collections
 from flask import current_app, request
 from werkzeug.datastructures import MultiDict, FileStorage
 from werkzeug import exceptions
@@ -173,7 +175,9 @@ class Argument(object):
                 if hasattr(source, "getlist"):
                     values = source.getlist(name)
                 else:
-                    values = [source.get(name)]
+                    values = source.get(name)
+                    if not isinstance(values, collections.MutableSequence):
+                        values = [values]
 
                 for value in values:
                     if hasattr(value, "strip") and self.trim:

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -302,6 +302,27 @@ class ReqParseTestCase(unittest.TestCase):
         args = parser.parse_args(req)
         self.assertEquals(args['foo'], ["bar"])
 
+    def test_parse_append_many(self):
+        req = Request.from_values("/bubble?foo=bar&foo=bar2")
+
+        parser = RequestParser()
+        parser.add_argument("foo", action="append"),
+
+        args = parser.parse_args(req)
+        self.assertEquals(args['foo'], ["bar", "bar2"])
+
+    def test_parse_append_many_location_json(self):
+        app = Flask(__name__)
+
+        parser = RequestParser()
+        parser.add_argument("foo", action='append', location="json")
+
+        with app.test_request_context('/bubble', method="post",
+                                      data=json.dumps({"foo": ["bar", "bar2"]}),
+                                      content_type='application/json'):
+            args = parser.parse_args()
+            self.assertEquals(args['foo'], ['bar', 'bar2'])
+
     def test_parse_dest(self):
         req = Request.from_values("/bubble?foo=bar")
 


### PR DESCRIPTION
This fix an issue when parsing a list value inside body data (JSON).

Value returned by `source.get(name)` can already be a list provided inside JSON data, so it should not be wrapped into another list in this case. The value should be used as is if it's already a sequence.