### PR TITLE
Fix formatting error in reqparse.tst

### DIFF
--- a/docs/reqparse.rst
+++ b/docs/reqparse.rst
@@ -226,20 +226,19 @@ then the error message will be the value of ``help``.
 
 ``help`` may include an interpolation token, ``{error_msg}``, that will be
 replaced with the string representation of the type error. This allows the
-message to be customized while preserving the original error:
+message to be customized while preserving the original error ::
 
     from flask_restful import reqparse
-
-
+    
     parser = reqparse.RequestParser()
     parser.add_argument(
         'foo',
         choices=('one', 'two'),
         help='Bad choice: {error_msg}'
     )
-
+    
     # If a request comes in with a value of "three" for `foo`:
-
+    
     {
         "message":  {
             "foo": "Bad choice: three is not a valid choice",

--- a/docs/reqparse.rst
+++ b/docs/reqparse.rst
@@ -229,14 +229,14 @@ replaced with the string representation of the type error. This allows the
 message to be customized while preserving the original error ::
 
     from flask_restful import reqparse
-    
+
     parser = reqparse.RequestParser()
     parser.add_argument(
         'foo',
         choices=('one', 'two'),
         help='Bad choice: {error_msg}'
     )
-    
+
     # If a request comes in with a value of "three" for `foo`:
     
     {

--- a/docs/reqparse.rst
+++ b/docs/reqparse.rst
@@ -238,7 +238,7 @@ message to be customized while preserving the original error ::
     )
 
     # If a request comes in with a value of "three" for `foo`:
-    
+
     {
         "message":  {
             "foo": "Bad choice: three is not a valid choice",


### PR DESCRIPTION
The last paragraph is not setting a proper formatting to the code block.