### PR TITLE
Include latest python version in installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,4 +24,4 @@ installed if you use ``pip``):
 
 * `Flask <http://flask.pocoo.org>`_ version 0.8 or greater
 
-Flask-RESTful requires Python version 2.6, 2.7, 3.3, or 3.4.
+Flask-RESTful requires Python version 2.6, 2.7, 3.3, 3.4, 3.5 or 3.6.


### PR DESCRIPTION
According to tox.ini py35 and py36 are supported or is there anything else that needs to be done to enable the support?