### PR TITLE
turn off key sorting of json response in python3

### DIFF
--- a/flask_restful/representations/json.py
+++ b/flask_restful/representations/json.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from flask import make_response, current_app
+from flask_restful.utils import PY3
 from json import dumps
 
 
@@ -13,7 +14,7 @@ def output_json(data, code, headers=None):
     # that was set.  We also set the "sort_keys" value.
     if current_app.debug:
         settings.setdefault('indent', 4)
-        settings.setdefault('sort_keys', True)
+        settings.setdefault('sort_keys', not PY3)
 
     # always end the json dumps with a new line
     # see https://github.com/mitsuhiko/flask/pull/1262

--- a/flask_restful/utils/__init__.py
+++ b/flask_restful/utils/__init__.py
@@ -1,9 +1,13 @@
+import sys
+
 try:
     from collections import OrderedDict
 except ImportError:
     from ordereddict import OrderedDict
 
 from werkzeug.http import HTTP_STATUS_CODES
+
+PY3 = sys.version_info > (3,)
 
 
 def http_status_message(code):


### PR DESCRIPTION
It's a simple work around to key sorting under Python 3.  
Related issue: #678