### PR TITLE
BugFix for python3 error handling

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -312,7 +312,7 @@ class Api(object):
 
         data = getattr(e, 'data', default_data)
 
-        if code >= 500:
+        if code and code >= 500:
             exc_info = sys.exc_info()
             if exc_info[1] is None:
                 exc_info = None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -139,7 +139,7 @@ class APITestCase(unittest.TestCase):
         resp = app.get('/bomb')
         self.assertEquals(resp.status_code, 409)
         self.assertEquals(resp.content_type, api.default_mediatype)
-        resp_dict = json.loads(resp.get_data().strip())
+        resp_dict = json.loads(resp.data.decode())
         self.assertEqual(resp_dict.get('status'), 409)
         self.assertEqual(resp_dict.get('message'), 'go away')
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,6 +43,7 @@ class HelloWorld(flask_restful.Resource):
 class BadMojoError(HTTPException):
     pass
 
+
 # Resource that always errors out
 class HelloBomb(flask_restful.Resource):
     def get(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,6 +40,15 @@ class HelloWorld(flask_restful.Resource):
         return {}
 
 
+class BadMojoError(HTTPException):
+    pass
+
+# Resource that always errors out
+class HelloBomb(flask_restful.Resource):
+    def get(self):
+        raise BadMojoError("It burns..")
+
+
 class APITestCase(unittest.TestCase):
 
     def test_http_code(self):
@@ -118,6 +127,20 @@ class APITestCase(unittest.TestCase):
             self.assertEquals(resp.status_code, 400)
             self.assertEquals(resp.get_data(), b'{"message": "x"}\n')
 
+
+    def test_handle_error_does_not_swallow_custom_exceptions(self):
+        app = Flask(__name__)
+        errors = {'BadMojoError': {'status': 409, 'message': 'go away'}}
+        api = flask_restful.Api(app, errors=errors)
+        api.add_resource(HelloBomb, '/bomb')
+
+        app = app.test_client()
+        resp = app.get('/bomb')
+        self.assertEquals(resp.status_code, 409)
+        self.assertEquals(resp.content_type, api.default_mediatype)
+        resp_dict = json.loads(resp.get_data().strip())
+        self.assertEqual(resp_dict.get('status'), 409)
+        self.assertEqual(resp_dict.get('message'), 'go away')
 
     def test_marshal(self):
         fields = OrderedDict([('foo', flask_restful.fields.Raw)])


### PR DESCRIPTION
This PR attempts to fix issue #685. Python 3 doesn't allow comparisons of different types (e.g. None > int). 