### PR TITLE
Should use or logic for :type, Union for python 3

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -50,8 +50,7 @@ class Api(object):
     after it has been constructed.
 
     :param app: the Flask application object
-    :type app: flask.Flask
-    :type app: flask.Blueprint
+    :type app: flask.Flask or flask.Blueprint
     :param prefix: Prefix all routes with a value, eg v1 or 2010-04-01
     :type prefix: str
     :param default_mediatype: The default media type to return


### PR DESCRIPTION
The current notation (specifying :type twice) is non-standard and causes linters/IDEs to pick up the lowest one. This is incorrect.
In python 2 and 3 or logic is the most standard, so I'm updating to that for backwards compatibility.
In python 3 Union[int, float] is the standard.