### PR TITLE
Removes download count

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://travis-ci.org/flask-restful/flask-restful.svg?branch=master)](http://travis-ci.org/flask-restful/flask-restful)
 [![Coverage Status](http://img.shields.io/coveralls/flask-restful/flask-restful/master.svg)](https://coveralls.io/r/flask-restful/flask-restful)
 [![PyPI Version](http://img.shields.io/pypi/v/Flask-RESTful.svg)](https://pypi.python.org/pypi/Flask-RESTful)
-[![PyPI Downloads](http://img.shields.io/pypi/dm/Flask-RESTful.svg)](https://pypi.python.org/pypi/Flask-RESTful)
 
 Flask-RESTful provides the building blocks for creating a great REST API.
 


### PR DESCRIPTION
Download count is not supported anymore. It was broken for a long period of time, but now it was completely removed.

That's how it looks right now:
<img width="482" alt="2017-11-22 10 40 39" src="https://user-images.githubusercontent.com/4660275/33115391-c80223b0-cf71-11e7-82ee-c851983d0e05.png">
So, I have removed this badge.