### PR TITLE
Make `fields.Nested` to take dynamic fields with callable

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -130,7 +130,8 @@ class Nested(Raw):
     """Allows you to nest one set of fields inside another.
     See :ref:`nested-field` for more information
 
-    :param dict nested: The dictionary to nest
+    :param nested: The dictionary to nest or the callable object
+        to generate the dictionary to nest
     :param bool allow_null: Whether to return None instead of a dictionary
         with null keys, if a nested dictionary has all-null keys
     :param kwargs: If ``default`` keyword argument is present, a nested
@@ -139,8 +140,8 @@ class Nested(Raw):
         null)
     """
 
-    def __init__(self, nested, allow_null=False, **kwargs):
-        self.nested = nested
+    def __init__(self, nested_or_callable, allow_null=False, **kwargs):
+        self.nested = nested_or_callable
         self.allow_null = allow_null
         super(Nested, self).__init__(**kwargs)
 
@@ -152,7 +153,8 @@ class Nested(Raw):
             elif self.default is not None:
                 return self.default
 
-        return marshal(value, self.nested)
+        nested = self.nested(value) if callable(self.nested) else self.nested
+        return marshal(value, nested)
 
 
 class List(Raw):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -487,6 +487,26 @@ class FieldsTestCase(unittest.TestCase):
         field = fields.Nested({'a': fields.Integer, 'b': fields.String}, default={})
         self.assertEquals({}, field.output('a', obj))
 
+    def test_callable_nested(self):
+        def dynamic_nested(value):
+            if 'a' in value:
+                field = {'a': fields.Integer}
+            elif 'c' in value:
+                field = {'c': fields.String}
+            elif 'e' in value:
+                field = {'f': fields.String}
+            return field
+
+        obj = {'list': [{'a': 1, 'b': 1},
+                        {'c': 'str', 'd': 2},
+                        {'e': 3, 'f': 'str'}]}
+        field = fields.List(fields.Nested(dynamic_nested))
+
+        self.assertEquals([OrderedDict([('a', 1)]),
+                           OrderedDict([('c', 'str')]),
+                           OrderedDict([('f', 'str')])],
+                          field.output('list', obj))
+
     def test_list_of_raw(self):
         obj = {'list': [{'a': 1, 'b': 1}, {'a': 2, 'b': 1}, {'a': 3, 'b': 1}]}
         field = fields.List(fields.Raw)


### PR DESCRIPTION
Sometimes, dynamic nested field is needed. (ex: various object types in `List` field)
I think, if `fields.Nested` can take a callable that generates `dict` type fields, that problem is simply solved.