### PR TITLE
Pin the `pytz` version used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     'aniso8601>=0.82',
     'Flask>=0.8',
     'six>=1.3.0',
-    'pytz',
+    'pytz<=2018.4',
 ]
 if PY26:
     requirements.append('ordereddict')


### PR DESCRIPTION
Having an unpinned dependency version can lead to requirements conflicts
if an app depends on both flask-restful and a pinned version of pytz.