### PR TITLE
Add __slots__ to Api class

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -72,6 +72,9 @@ class Api(object):
     :type errors: dict
 
     """
+    __slots__ = ['representations', 'urls', 'prefix', 'default_mediatype', 'decorators', 'catch_all_404s',
+                 'serve_challenge_on_401', 'url_part_order', 'errors', 'blueprint_setup', 'endpoints', 'resources',
+                 'app', 'blueprint']
 
     def __init__(self, app=None, prefix='',
                  default_mediatype='application/json', decorators=None,


### PR DESCRIPTION
In Python every class can have instance attributes. By default Python uses a dict to store an object’s instance attributes. This is really helpful as it allows setting arbitrary new attributes at runtime. However, for small classes with known attributes it might be a bottleneck. The dict wastes a lot of RAM.

Then, I added \_\_slots\_\_ to `Api` class, below is the result of testing the performance with ironpython.

### Before \_\_slots\_\_
```
In [1]: from flask import Flask

In [2]: from flask_restful import Api

In [3]: import ipython_memory_usage.ipython_memory_usage as imu

In [4]: size = 1024 * 128

In [5]: app = Flask(__name__)

In [6]: imu.start_watching_memory()
In [6] used 0.2734 MiB RAM in 24.30s, peaked 0.00 MiB above current, total RAM usage 62.41 MiB

In [7]: x = [Api(app) for _ in range(size)]
In [7] used 306.2891 MiB RAM in 2.28s, peaked 0.00 MiB above current, total RAM usage 368.70 MiB

In [8]: Api(app)
Out[8]: <flask_restful.Api at 0x123a75978>
In [8] used 0.1406 MiB RAM in 0.10s, peaked 0.00 MiB above current, total RAM usage 368.84 MiB
```

### After \_\_slots\_\_
```
In [1]: from flask import Flask

In [2]: from flask_restful import Api

In [3]: import ipython_memory_usage.ipython_memory_usage as imu

In [4]: size = 1024 * 128

In [5]: app = Flask(__name__)

In [6]: imu.start_watching_memory()
In [6] used 0.0391 MiB RAM in 11.06s, peaked 0.00 MiB above current, total RAM usage 62.62 MiB

In [7]: x = [Api(app) for _ in range(size)]
In [7] used 286.3320 MiB RAM in 2.05s, peaked 0.00 MiB above current, total RAM usage 350.95 MiB

In [8]: Api(app)
Out[8]: <flask_restfu.Api at 0x133ac6898>
In [8] used 0.0547 MiB RAM in 0.11s, peaked 0.00 MiB above current, total RAM usage 639.41 MiB
```