### PR TITLE
check if request body is a dict instead of assuming it is

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -104,8 +104,11 @@ class Argument(object):
                 value = getattr(request, l, None)
                 if callable(value):
                     value = value()
-                if value is not None:
-                    values.update(value)
+                if value is None:
+                    continue
+                if not isinstance(value, dict):
+                    continue
+                values.update(value)
             return values
 
         return MultiDict()


### PR DESCRIPTION
Inside of a request handler, I have a code like this:

```
    parser = RequestParser()
    parser.add_argument('id', type=str, required=True)
    args = self.post_parser.parse_args(strict=True)
```

This fails with a `ValueError` on the last line if the user sends a list instead of a dict as request body.

As far as I could understand, the problem happens on reqparse.py:108, when it assumes the value to be something that is understandable by `values.update`, though `MultiDict.update` expects a `dict` (or subtypes) or something that on iteration yields a pair (key, value). My understanding of reqparse code is that in this case, we should only be passing a dict.