### PR TITLE
test_api: fix traceback

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -777,7 +777,7 @@ class APITestCase(unittest.TestCase):
         allow = ', '.join(set(resp.headers.get_all('Allow')))
         allow = set(method.strip() for method in allow.split(','))
         self.assertEquals(allow,
-                          set(['HEAD', 'OPTIONS'] + HelloWorld.methods))
+                          set(['HEAD', 'OPTIONS'] + list(HelloWorld.methods)))
 
     def test_exception_header_forwarded(self):
         """Test that HTTPException's headers are extended properly"""


### PR DESCRIPTION
This is fixed:
```
Traceback (most recent call last):
  File "/builddir/build/BUILD/flask-restful-0.3.6/tests/test_api.py", line 787, in test_fr_405
    set(['HEAD', 'OPTIONS'] + HelloWorld.methods))
TypeError: can only concatenate list (not "set") to list
```