### PR TITLE
Typo in test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -91,7 +91,7 @@ class APITestCase(unittest.TestCase):
         with app.test_request_context('/foo'):
             resp = api.handle_error(Unauthorized())
             self.assertEquals(resp.status_code, 401)
-            assert_false('WWW-Autheneticate' in resp.headers)
+            assert_false('WWW-Authenticate' in resp.headers)
 
     def test_handle_error_401_sends_challege_default_realm(self):
         app = Flask(__name__)


### PR DESCRIPTION
Just a bug I caught while reading through the test code.

Changed `WWW-Autheneticate` to `WWW-Authenticate`