### PR TITLE
utf-8 supported string for all non latin-1 characters resolves #767

### DIFF
--- a/flask_restful/fields.py
+++ b/flask_restful/fields.py
@@ -218,6 +218,19 @@ class String(Raw):
             raise MarshallingException(ve)
 
 
+class StringEncoded(Raw):
+    """
+    Marshal a value as a string. Uses ``six.u`` uses string unicode-escape to
+    unicode in the string. It is useful for utf-8 characters and also for all
+    emojis like utf8mb4
+    """
+    def format(self, value):
+        try:
+            return six.u(value)
+        except ValueError as ve:
+            raise MarshallingException(ve)
+
+
 class Integer(Raw):
     """ Field for outputting an integer value.
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -359,15 +359,15 @@ class FieldsTestCase(unittest.TestCase):
         self.assertEquals(None, field.output("empty", {'empty': None}))
 
     def test_string_encoded(self):
-        field = fields.String()
+        field = fields.StringEncoded()
         self.assertEquals("3", field.output("hey", Foo()))
 
     def test_string_encoded_no_value(self):
-        field = fields.String()
+        field = fields.StringEncoded()
         self.assertEquals(None, field.output("bar", Foo()))
 
     def test_string_encoded_none(self):
-        field = fields.String()
+        field = fields.StringEncoded()
         self.assertEquals(None, field.output("empty", {'empty': None}))
 
     def test_rfc822_date_field_without_offset(self):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -358,6 +358,18 @@ class FieldsTestCase(unittest.TestCase):
         field = fields.String()
         self.assertEquals(None, field.output("empty", {'empty': None}))
 
+    def test_string_encoded(self):
+        field = fields.String()
+        self.assertEquals("3", field.output("hey", Foo()))
+
+    def test_string_encoded_no_value(self):
+        field = fields.String()
+        self.assertEquals(None, field.output("bar", Foo()))
+
+    def test_string_encoded_none(self):
+        field = fields.String()
+        self.assertEquals(None, field.output("empty", {'empty': None}))
+
     def test_rfc822_date_field_without_offset(self):
         obj = {"bar": datetime(2011, 8, 22, 20, 58, 45)}
         field = fields.DateTime()


### PR DESCRIPTION
This merge will handle all the utf-8 characters in marshal_with of flask_restful. fields.String is not handling non latin-1 characters