### PR TITLE
Fixed bug with custom view_func

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -419,8 +419,11 @@ class Api(object):
 
         resource.mediatypes = self.mediatypes_method()  # Hacky
         resource.endpoint = endpoint
-        resource_func = self.output(resource.as_view(endpoint, *resource_class_args,
-            **resource_class_kwargs))
+        if 'view_func' not in kwargs:
+            resource_func = self.output(resource.as_view(endpoint, *resource_class_args,
+                **resource_class_kwargs))
+        else:
+            resource_func = kwargs.pop('view_func')
 
         for decorator in self.decorators:
             resource_func = decorator(resource_func)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -593,6 +593,17 @@ class APITestCase(unittest.TestCase):
         app.add_url_rule.assert_called_with('/foo',
                                             view_func=api.output())
 
+    def test_add_resource_with_custom_view_func(self):
+        app = Mock(flask.Flask)
+        app.view_functions = {}
+        api = flask_restful.Api(app)
+        api.output = Mock()
+        custom_func = Mock()
+        api.add_resource(views.MethodView, '/foo', view_func=custom_func())
+
+        app.add_url_rule.assert_called_with('/foo',
+                                            view_func=custom_func())
+
     def test_resource_decorator(self):
         app = Mock(flask.Flask)
         app.view_functions = {}


### PR DESCRIPTION
- When supplying view_func to Api.add_resource, it would not pass the
custom view all the way through to App.add_url_rule. This commit ensures
that custom view_funcs are passed through successfully.