### PR TITLE
Remove "WWW-Authenticate" from response headers by default

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -303,6 +303,12 @@ class Api(object):
         # https://github.com/flask-restful/flask-restful/issues/534
         remove_headers = ('Content-Length',)
 
+        if not self.serve_challenge_on_401:
+            # remove "WWW-Authenticate" in resp.headers if self.serve_challenge_on_401 is set to False.
+            # required for passing tests/test_api.py test_handle_error_401_no_challenge_by_default.
+            remove_headers += ('WWW-Authenticate',)
+
+
         for header in remove_headers:
             headers.pop(header, None)
 


### PR DESCRIPTION
Fix failed test in travis CI: test_handle_error_401_no_challenge_by_default
```
/home/travis/virtualenv/python3.7.1/bin/nosetests tests --with-coverage --cover-package=flask_restful
........................................F.......................................................................................................................................................................................................................................................................................................................................................................
======================================================================
FAIL: test_handle_error_401_no_challenge_by_default (tests.test_api.APITestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/flask-restful/flask-restful/tests/test_api.py", line 94, in test_handle_error_401_no_challenge_by_default
    assert_false('WWW-Authenticate' in resp.headers)
AssertionError: True is not false
```

Fix: remove "WWW-Authenticate" from response headers if self.serve_challenge_on_401 is False (this variable is set to False by default). 

Fix #809 

Potential Error/Side Effect:
- May override "WWW-Authenticate" if keyword argument serve_challenge_on_401 is not set to True when initializing Api. 