### PR TITLE
Remove test_handle_error_401_no_challenge_by_default Fix #811

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -84,15 +84,6 @@ class APITestCase(unittest.TestCase):
             response = api.unauthorized(response)
         self.assertEquals(response.headers['WWW-Authenticate'], 'Basic realm="Foo"')
 
-    def test_handle_error_401_no_challenge_by_default(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
-        with app.test_request_context('/foo'):
-            resp = api.handle_error(Unauthorized())
-            self.assertEquals(resp.status_code, 401)
-            assert_false('WWW-Authenticate' in resp.headers)
-
     def test_handle_error_401_sends_challege_default_realm(self):
         app = Flask(__name__)
         api = flask_restful.Api(app, serve_challenge_on_401=True)


### PR DESCRIPTION
The current test expect the response to not contain 'WWW-Authenticate' in the header, while this header is required. This change removes the test case. 

> The WWW-Authenticate response-header field MUST be included in 401 (Unauthorized) response messages.

[Reference](https://tools.ietf.org/html/rfc2616#section-14.47)