### PR TITLE
Fix overridden response when calling abort with Response; Resolves #791

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -287,6 +287,13 @@ class Api(object):
 
         headers = Headers()
         if isinstance(e, HTTPException):
+            if e.response is not None:
+                # If HTTPException is initialized with a response, then return e.get_response().
+                # This prevents specified error response from being overridden.
+                # eg. HTTPException(response=Response("Hello World"))
+                resp = e.get_response()
+                return resp
+
             code = e.code
             default_data = {
                 'message': getattr(e, 'description', http_status_message(code))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -133,6 +133,24 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(resp_dict.get('status'), 409)
         self.assertEqual(resp_dict.get('message'), 'go away')
 
+    def test_handle_error_does_not_swallow_abort_response(self):
+
+        class HelloBombAbort(flask_restful.Resource):
+            def get(self):
+                raise HTTPException(response=flask.make_response("{}", 403))
+
+        app = Flask(__name__)
+        api = flask_restful.Api(app)
+        api.add_resource(HelloBombAbort, '/bomb')
+
+        app = app.test_client()
+        resp = app.get('/bomb')
+
+        resp_dict = json.loads(resp.data.decode())
+
+        self.assertEquals(resp.status_code, 403)
+        self.assertDictEqual(resp_dict, {})
+
     def test_marshal(self):
         fields = OrderedDict([('foo', flask_restful.fields.Raw)])
         marshal_dict = OrderedDict([('foo', 'bar'), ('bat', 'baz')])


### PR DESCRIPTION
Side effect: if e.response is not None, error messages and other information stored in e: HTTPException may be overridden. 