### PR TITLE
Set self.app when app is a Flask application object

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -197,6 +197,8 @@ class Api(object):
             for resource, urls, kwargs in self.resources:
                 self._register_view(app, resource, *urls, **kwargs)
 
+        self.app = app
+
     def owns_endpoint(self, endpoint):
         """Tests if an endpoint name (not path) belongs to this Api.  Takes
         in to account the Blueprint name part of the endpoint name.


### PR DESCRIPTION
Today I was trying to implement flask-restful in a project and it just wasn't working for some reason. Routes couldn't be found, even with the most basic "hello world" example. I use a factory pattern to create the app object at runtime, so I don't initialize any extensions by passing the `app` object, and instead call `init_app` on all of them. The issue was, when `Api#init_app` was called, `self.app` was never set. It is only set when `app` is passed to the constructor. Adding this line of code to make sure `self.app` is initialized when `init_app` is called made everything work for me.