### PR TITLE
add note about custom exceptions

### DIFF
--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -272,4 +272,4 @@ Once your ``errors`` dictionary is defined, simply pass it to the
     app = Flask(__name__)
     api = flask_restful.Api(app, errors=errors)
 
-NB: Custom `Exceptions` must have  :class:`~werkzeug.exceptions.HTTPException` as the base Exception.
+Note: Custom `Exceptions` must have  :class:`~werkzeug.exceptions.HTTPException` as the base Exception.

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -271,3 +271,5 @@ Once your ``errors`` dictionary is defined, simply pass it to the
 
     app = Flask(__name__)
     api = flask_restful.Api(app, errors=errors)
+
+NB: Custom `Exceptions` must have  :class:`~werkzeug.exceptions.HTTPException` as the base Exception.


### PR DESCRIPTION
Updating docs to include a line about Custom Error Messages, requiring that the exception has  `HTTPException` as the parent.