### PR TITLE
Refactor tests to remove repetition.

### DIFF
--- a/tests/test_accept.py
+++ b/tests/test_accept.py
@@ -1,148 +1,87 @@
 import unittest
+
 from flask import Flask
-import flask_restful
-from werkzeug import exceptions
 from nose.tools import assert_equals
 
+import flask_restful
 
 
 class AcceptTestCase(unittest.TestCase):
 
-    def test_accept_default_application_json(self):
+    def setUp(self):
 
         class Foo(flask_restful.Resource):
             def get(self):
                 return "data"
 
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
+        self.app = Flask(__name__)
+        self.api = flask_restful.Api(self.app)
+        self.api.add_resource(Foo, '/')
 
-        api.add_resource(Foo, '/')
+        self.app_no_mediatype = Flask(__name__)
+        self.api_no_mediatype = flask_restful.Api(self.app_no_mediatype, default_mediatype=None)
+        self.api_no_mediatype.add_resource(Foo, '/')
 
-        with app.test_client() as client:
+    def test_accept_default_application_json(self):
+        with self.app.test_client() as client:
             res = client.get('/', headers=[('Accept', 'application/json')])
             assert_equals(res.status_code, 200)
             assert_equals(res.content_type, 'application/json')
-
 
     def test_accept_no_default_match_acceptable(self):
-
-        class Foo(flask_restful.Resource):
-            def get(self):
-                return "data"
-
-        app = Flask(__name__)
-        api = flask_restful.Api(app, default_mediatype=None)
-
-        api.add_resource(Foo, '/')
-
-        with app.test_client() as client:
+        with self.app_no_mediatype.test_client() as client:
             res = client.get('/', headers=[('Accept', 'application/json')])
             assert_equals(res.status_code, 200)
             assert_equals(res.content_type, 'application/json')
 
-
     def test_accept_default_override_accept(self):
-
-        class Foo(flask_restful.Resource):
-            def get(self):
-                return "data"
-
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
-        api.add_resource(Foo, '/')
-
-        with app.test_client() as client:
+        with self.app.test_client() as client:
             res = client.get('/', headers=[('Accept', 'text/plain')])
             assert_equals(res.status_code, 200)
             assert_equals(res.content_type, 'application/json')
 
-
     def test_accept_default_any_pick_first(self):
-
-        class Foo(flask_restful.Resource):
-            def get(self):
-                return "data"
-
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
-        @api.representation('text/plain')
+        @self.api.representation('text/plain')
         def text_rep(data, status_code, headers=None):
-            resp = app.make_response((str(data), status_code, headers))
+            resp = self.app.make_response((str(data), status_code, headers))
             return resp
 
-        api.add_resource(Foo, '/')
-
-        with app.test_client() as client:
+        with self.app.test_client() as client:
             res = client.get('/', headers=[('Accept', '*/*')])
             assert_equals(res.status_code, 200)
             assert_equals(res.content_type, 'application/json')
 
-
     def test_accept_no_default_no_match_not_acceptable(self):
-
-        class Foo(flask_restful.Resource):
-            def get(self):
-                return "data"
-
-        app = Flask(__name__)
-        api = flask_restful.Api(app, default_mediatype=None)
-
-        api.add_resource(Foo, '/')
-
-        with app.test_client() as client:
+        with self.app_no_mediatype.test_client() as client:
             res = client.get('/', headers=[('Accept', 'text/plain')])
             assert_equals(res.status_code, 406)
             assert_equals(res.content_type, 'application/json')
 
-
     def test_accept_no_default_custom_repr_match(self):
+        self.api_no_mediatype.representations = {}
 
-        class Foo(flask_restful.Resource):
-            def get(self):
-                return "data"
-
-        app = Flask(__name__)
-        api = flask_restful.Api(app, default_mediatype=None)
-        api.representations = {}
-
-        @api.representation('text/plain')
+        @self.api_no_mediatype.representation('text/plain')
         def text_rep(data, status_code, headers=None):
-            resp = app.make_response((str(data), status_code, headers))
+            resp = self.app_no_mediatype.make_response((str(data), status_code, headers))
             return resp
 
-        api.add_resource(Foo, '/')
-
-        with app.test_client() as client:
+        with self.app_no_mediatype.test_client() as client:
             res = client.get('/', headers=[('Accept', 'text/plain')])
             assert_equals(res.status_code, 200)
             assert_equals(res.content_type, 'text/plain')
 
-
     def test_accept_no_default_custom_repr_not_acceptable(self):
+        self.api_no_mediatype.representations = {}
 
-        class Foo(flask_restful.Resource):
-            def get(self):
-                return "data"
-
-        app = Flask(__name__)
-        api = flask_restful.Api(app, default_mediatype=None)
-        api.representations = {}
-
-        @api.representation('text/plain')
+        @self.api_no_mediatype.representation('text/plain')
         def text_rep(data, status_code, headers=None):
-            resp = app.make_response((str(data), status_code, headers))
+            resp = self.app_no_mediatype.make_response((str(data), status_code, headers))
             return resp
 
-        api.add_resource(Foo, '/')
-
-        with app.test_client() as client:
+        with self.app_no_mediatype.test_client() as client:
             res = client.get('/', headers=[('Accept', 'application/json')])
             assert_equals(res.status_code, 406)
             assert_equals(res.content_type, 'text/plain')
-
 
     def test_accept_no_default_match_q0_not_acceptable(self):
         """
@@ -150,82 +89,43 @@ class AcceptTestCase(unittest.TestCase):
         but this depends on werkzeug >= 1.0 which is not yet released
         so this test is expected to fail until we depend on werkzeug >= 1.0
         """
-        class Foo(flask_restful.Resource):
-            def get(self):
-                return "data"
-
-        app = Flask(__name__)
-        api = flask_restful.Api(app, default_mediatype=None)
-
-        api.add_resource(Foo, '/')
-
-        with app.test_client() as client:
+        with self.app_no_mediatype.test_client() as client:
             res = client.get('/', headers=[('Accept', 'application/json; q=0')])
             assert_equals(res.status_code, 406)
             assert_equals(res.content_type, 'application/json')
 
     def test_accept_no_default_accept_highest_quality_of_two(self):
-        class Foo(flask_restful.Resource):
-            def get(self):
-                return "data"
-
-        app = Flask(__name__)
-        api = flask_restful.Api(app, default_mediatype=None)
-
-        @api.representation('text/plain')
+        @self.api_no_mediatype.representation('text/plain')
         def text_rep(data, status_code, headers=None):
-            resp = app.make_response((str(data), status_code, headers))
+            resp = self.app_no_mediatype.make_response((str(data), status_code, headers))
             return resp
 
-        api.add_resource(Foo, '/')
-
-        with app.test_client() as client:
+        with self.app_no_mediatype.test_client() as client:
             res = client.get('/', headers=[('Accept', 'application/json; q=0.1, text/plain; q=1.0')])
             assert_equals(res.status_code, 200)
             assert_equals(res.content_type, 'text/plain')
 
-
     def test_accept_no_default_accept_highest_quality_of_three(self):
-        class Foo(flask_restful.Resource):
-            def get(self):
-                return "data"
-
-        app = Flask(__name__)
-        api = flask_restful.Api(app, default_mediatype=None)
-
-        @api.representation('text/html')
-        @api.representation('text/plain')
+        @self.api_no_mediatype.representation('text/html')
+        @self.api_no_mediatype.representation('text/plain')
         def text_rep(data, status_code, headers=None):
-            resp = app.make_response((str(data), status_code, headers))
+            resp = self.app_no_mediatype.make_response((str(data), status_code, headers))
             return resp
 
-        api.add_resource(Foo, '/')
-
-        with app.test_client() as client:
+        with self.app_no_mediatype.test_client() as client:
             res = client.get('/', headers=[('Accept', 'application/json; q=0.1, text/plain; q=0.3, text/html; q=0.2')])
             assert_equals(res.status_code, 200)
             assert_equals(res.content_type, 'text/plain')
 
-
     def test_accept_no_default_no_representations(self):
+        self.api_no_mediatype.representations = {}
 
-        class Foo(flask_restful.Resource):
-            def get(self):
-                return "data"
-
-        app = Flask(__name__)
-        api = flask_restful.Api(app, default_mediatype=None)
-        api.representations = {}
-
-        api.add_resource(Foo, '/')
-
-        with app.test_client() as client:
+        with self.app_no_mediatype.test_client() as client:
             res = client.get('/', headers=[('Accept', 'text/plain')])
             assert_equals(res.status_code, 406)
             assert_equals(res.content_type, 'text/plain')
 
     def test_accept_invalid_default_no_representations(self):
-
         class Foo(flask_restful.Resource):
             def get(self):
                 return "data"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,24 +1,26 @@
-import unittest
 import json
-from flask import Flask, Blueprint, redirect, views, abort as flask_abort
-from flask.signals import got_request_exception, signals_available
+from json import dumps, loads, JSONEncoder
+import unittest
 try:
     from mock import Mock
 except:
     # python3
     from unittest.mock import Mock
+
+
 import flask
-import werkzeug
-from werkzeug.exceptions import HTTPException, Unauthorized, BadRequest, NotFound, _aborter
+from flask import Flask, Blueprint, redirect, views, abort as flask_abort
+from flask.signals import got_request_exception, signals_available
+#noinspection PyUnresolvedReferences
+from nose.tools import assert_equals, assert_true, assert_false  # you need it for tests in form of continuations
+import six
+from werkzeug.exceptions import HTTPException, Unauthorized, BadRequest, _aborter
 from werkzeug.http import quote_etag, unquote_etag
+
 from flask_restful.utils import http_status_message, unpack
 import flask_restful
 import flask_restful.fields
 from flask_restful import OrderedDict
-from json import dumps, loads, JSONEncoder
-#noinspection PyUnresolvedReferences
-from nose.tools import assert_equals, assert_true, assert_false  # you need it for tests in form of continuations
-import six
 
 
 def check_unpack(expected, value):
@@ -51,73 +53,69 @@ class HelloBomb(flask_restful.Resource):
 
 class APITestCase(unittest.TestCase):
 
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.api = flask_restful.Api(self.app)
+
+        self.app_401 = Flask(__name__)
+        self.api_401 = flask_restful.Api(self.app, serve_challenge_on_401=True)
+
+        self.fields = OrderedDict([('foo', flask_restful.fields.Raw)])
+
     def test_http_code(self):
         self.assertEquals(http_status_message(200), 'OK')
         self.assertEquals(http_status_message(404), 'Not Found')
 
     def test_unauthorized_no_challenge_by_default(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
         response = Mock()
         response.headers = {}
-        with app.test_request_context('/foo'):
-            response = api.unauthorized(response)
+        with self.app.test_request_context('/foo'):
+            response = self.api.unauthorized(response)
         assert_false('WWW-Authenticate' in response.headers)
 
     def test_unauthorized(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app, serve_challenge_on_401=True)
         response = Mock()
         response.headers = {}
-        with app.test_request_context('/foo'):
-            response = api.unauthorized(response)
+        with self.app_401.test_request_context('/foo'):
+            response = self.api_401.unauthorized(response)
         self.assertEquals(response.headers['WWW-Authenticate'],
                           'Basic realm="flask-restful"')
 
     def test_unauthorized_custom_realm(self):
-        app = Flask(__name__)
-        app.config['HTTP_BASIC_AUTH_REALM'] = 'Foo'
-        api = flask_restful.Api(app, serve_challenge_on_401=True)
+        self.app_401.config['HTTP_BASIC_AUTH_REALM'] = 'Foo'
         response = Mock()
         response.headers = {}
-        with app.test_request_context('/foo'):
-            response = api.unauthorized(response)
+        with self.app_401.test_request_context('/foo'):
+            response = self.api_401.unauthorized(response)
         self.assertEquals(response.headers['WWW-Authenticate'], 'Basic realm="Foo"')
 
     def test_handle_error_401_sends_challege_default_realm(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app, serve_challenge_on_401=True)
         exception = HTTPException()
         exception.code = 401
         exception.data = {'foo': 'bar'}
 
-        with app.test_request_context('/foo'):
-            resp = api.handle_error(exception)
+        with self.app_401.test_request_context('/foo'):
+            resp = self.api_401.handle_error(exception)
             self.assertEquals(resp.status_code, 401)
             self.assertEquals(resp.headers['WWW-Authenticate'],
                               'Basic realm="flask-restful"')
 
     def test_handle_error_401_sends_challege_configured_realm(self):
-        app = Flask(__name__)
-        app.config['HTTP_BASIC_AUTH_REALM'] = 'test-realm'
-        api = flask_restful.Api(app, serve_challenge_on_401=True)
+        self.app_401.config['HTTP_BASIC_AUTH_REALM'] = 'test-realm'
 
-        with app.test_request_context('/foo'):
-            resp = api.handle_error(Unauthorized())
+        with self.app_401.test_request_context('/foo'):
+            resp = self.api_401.handle_error(Unauthorized())
             self.assertEquals(resp.status_code, 401)
             self.assertEquals(resp.headers['WWW-Authenticate'],
                               'Basic realm="test-realm"')
 
     def test_handle_error_does_not_swallow_exceptions(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
         exception = BadRequest('x')
 
-        with app.test_request_context('/foo'):
-            resp = api.handle_error(exception)
+        with self.app.test_request_context('/foo'):
+            resp = self.api.handle_error(exception)
             self.assertEquals(resp.status_code, 400)
             self.assertEquals(resp.get_data(), b'{"message": "x"}\n')
-
 
     def test_handle_error_does_not_swallow_custom_exceptions(self):
         app = Flask(__name__)
@@ -138,12 +136,9 @@ class APITestCase(unittest.TestCase):
         class HelloBombAbort(flask_restful.Resource):
             def get(self):
                 raise HTTPException(response=flask.make_response("{}", 403))
+        self.api.add_resource(HelloBombAbort, '/bomb')
 
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-        api.add_resource(HelloBombAbort, '/bomb')
-
-        app = app.test_client()
+        app = self.app.test_client()
         resp = app.get('/bomb')
 
         resp_dict = json.loads(resp.data.decode())
@@ -152,46 +147,36 @@ class APITestCase(unittest.TestCase):
         self.assertDictEqual(resp_dict, {})
 
     def test_marshal(self):
-        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
         marshal_dict = OrderedDict([('foo', 'bar'), ('bat', 'baz')])
-        output = flask_restful.marshal(marshal_dict, fields)
+        output = flask_restful.marshal(marshal_dict, self.fields)
         self.assertEquals(output, {'foo': 'bar'})
 
     def test_marshal_with_envelope(self):
-        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
         marshal_dict = OrderedDict([('foo', 'bar'), ('bat', 'baz')])
-        output = flask_restful.marshal(marshal_dict, fields, envelope='hey')
+        output = flask_restful.marshal(marshal_dict, self.fields, envelope='hey')
         self.assertEquals(output, {'hey': {'foo': 'bar'}})
 
     def test_marshal_decorator(self):
-        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
-
-        @flask_restful.marshal_with(fields)
+        @flask_restful.marshal_with(self.fields)
         def try_me():
             return OrderedDict([('foo', 'bar'), ('bat', 'baz')])
         self.assertEquals(try_me(), {'foo': 'bar'})
 
     def test_marshal_decorator_with_envelope(self):
-        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
-
-        @flask_restful.marshal_with(fields, envelope='hey')
+        @flask_restful.marshal_with(self.fields, envelope='hey')
         def try_me():
             return OrderedDict([('foo', 'bar'), ('bat', 'baz')])
 
         self.assertEquals(try_me(), {'hey': {'foo': 'bar'}})
 
     def test_marshal_decorator_tuple(self):
-        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
-
-        @flask_restful.marshal_with(fields)
+        @flask_restful.marshal_with(self.fields)
         def try_me():
             return OrderedDict([('foo', 'bar'), ('bat', 'baz')]), 200, {'X-test': 123}
         self.assertEquals(try_me(), ({'foo': 'bar'}, 200, {'X-test': 123}))
 
     def test_marshal_decorator_tuple_with_envelope(self):
-        fields = OrderedDict([('foo', flask_restful.fields.Raw)])
-
-        @flask_restful.marshal_with(fields, envelope='hey')
+        @flask_restful.marshal_with(self.fields, envelope='hey')
         def try_me():
             return OrderedDict([('foo', 'bar'), ('bat', 'baz')]), 200, {'X-test': 123}
 
@@ -214,21 +199,18 @@ class APITestCase(unittest.TestCase):
         self.assertEquals(('foo', 200, {'X-test': 123}), try_me())
 
     def test_marshal_field(self):
-        fields = OrderedDict({'foo': flask_restful.fields.Raw()})
         marshal_fields = OrderedDict([('foo', 'bar'), ('bat', 'baz')])
-        output = flask_restful.marshal(marshal_fields, fields)
+        output = flask_restful.marshal(marshal_fields, self.fields)
         self.assertEquals(output, {'foo': 'bar'})
 
     def test_marshal_tuple(self):
-        fields = OrderedDict({'foo': flask_restful.fields.Raw})
         marshal_fields = OrderedDict([('foo', 'bar'), ('bat', 'baz')])
-        output = flask_restful.marshal((marshal_fields,), fields)
+        output = flask_restful.marshal((marshal_fields,), self.fields)
         self.assertEquals(output, [{'foo': 'bar'}])
 
     def test_marshal_tuple_with_envelope(self):
-        fields = OrderedDict({'foo': flask_restful.fields.Raw})
         marshal_fields = OrderedDict([('foo', 'bar'), ('bat', 'baz')])
-        output = flask_restful.marshal((marshal_fields,), fields, envelope='hey')
+        output = flask_restful.marshal((marshal_fields,), self.fields, envelope='hey')
         self.assertEquals(output, {'hey': [{'foo': 'bar'}]})
 
     def test_marshal_nested(self):
@@ -397,24 +379,19 @@ class APITestCase(unittest.TestCase):
             }) + "\n")
 
     def test_handle_error_with_code(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app, serve_challenge_on_401=True)
-
         exception = Exception()
         exception.code = "Not an integer"
         exception.data = {'foo': 'bar'}
 
-        with app.test_request_context("/foo"):
-            resp = api.handle_error(exception)
+        with self.app_401.test_request_context("/foo"):
+            resp = self.api_401.handle_error(exception)
             self.assertEquals(resp.status_code, 500)
             self.assertEquals(resp.data.decode(), dumps({"foo": "bar"}) + "\n")
 
     def test_handle_auth(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app, serve_challenge_on_401=True)
 
-        with app.test_request_context("/foo"):
-            resp = api.handle_error(Unauthorized())
+        with self.app_401.test_request_context("/foo"):
+            resp = self.api_401.handle_error(Unauthorized())
             self.assertEquals(resp.status_code, 401)
             expected_data = dumps({'message': Unauthorized.description}) + "\n"
             self.assertEquals(resp.data.decode(), expected_data)
@@ -422,15 +399,12 @@ class APITestCase(unittest.TestCase):
             self.assertTrue('WWW-Authenticate' in resp.headers)
 
     def test_handle_api_error(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
         class Test(flask_restful.Resource):
             def get(self):
                 flask.abort(404)
 
-        api.add_resource(Test(), '/api', endpoint='api')
-        app = app.test_client()
+        self.api.add_resource(Test(), '/api', endpoint='api')
+        app = self.app.test_client()
 
         resp = app.get("/api")
         assert_equals(resp.status_code, 404)
@@ -439,9 +413,7 @@ class APITestCase(unittest.TestCase):
         assert_true('message' in data)
 
     def test_handle_non_api_error(self):
-        app = Flask(__name__)
-        flask_restful.Api(app)
-        app = app.test_client()
+        app = self.app.test_client()
 
         resp = app.get("/foo")
         self.assertEquals(resp.status_code, 404)
@@ -460,8 +432,6 @@ class APITestCase(unittest.TestCase):
             # This test requires the blinker lib to run.
             print("Can't test signals without signal support")
             return
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
 
         exception = BadRequest()
 
@@ -470,21 +440,18 @@ class APITestCase(unittest.TestCase):
         def record(sender, exception):
             recorded.append(exception)
 
-        got_request_exception.connect(record, app)
+        got_request_exception.connect(record, self.app)
         try:
-            with app.test_request_context("/foo"):
-                api.handle_error(exception)
+            with self.app.test_request_context("/foo"):
+                self.api.handle_error(exception)
                 self.assertEquals(len(recorded), 1)
                 self.assertTrue(exception is recorded[0])
         finally:
-            got_request_exception.disconnect(record, app)
+            got_request_exception.disconnect(record, self.app)
 
     def test_handle_error(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
-        with app.test_request_context("/foo"):
-            resp = api.handle_error(BadRequest())
+        with self.app.test_request_context("/foo"):
+            resp = self.api.handle_error(BadRequest())
             self.assertEquals(resp.status_code, 400)
             self.assertEquals(resp.data.decode(), dumps({
                 'message': BadRequest.description,
@@ -494,45 +461,34 @@ class APITestCase(unittest.TestCase):
         """Verify that if an exception occurs in the Flask-RESTful error handler,
         the error_router will call the original flask error handler instead.
         """
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-        app.handle_exception = Mock()
-        api.handle_error = Mock(side_effect=Exception())
-        api._has_fr_route = Mock(return_value=True)
+        self.app.handle_exception = Mock()
+        self.api.handle_error = Mock(side_effect=Exception())
+        self.api._has_fr_route = Mock(return_value=True)
         exception = Mock(spec=HTTPException)
 
-        with app.test_request_context('/foo'):
-            api.error_router(exception, app.handle_exception)
+        with self.app.test_request_context('/foo'):
+            self.api.error_router(exception, self.app.handle_exception)
 
-        self.assertTrue(app.handle_exception.called_with(exception))
+        self.assertTrue(self.app.handle_exception.called_with(exception))
 
     def test_media_types(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
-        with app.test_request_context("/foo", headers={
+        with self.app.test_request_context("/foo", headers={
             'Accept': 'application/json'
         }):
-            self.assertEquals(api.mediatypes(), ['application/json'])
+            self.assertEquals(self.api.mediatypes(), ['application/json'])
 
     def test_media_types_method(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
-        with app.test_request_context("/foo", headers={
+        with self.app.test_request_context("/foo", headers={
             'Accept': 'application/xml; q=.5'
         }):
-            self.assertEquals(api.mediatypes_method()(Mock()),
+            self.assertEquals(self.api.mediatypes_method()(Mock()),
                               ['application/xml', 'application/json'])
 
     def test_media_types_q(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
-        with app.test_request_context("/foo", headers={
+        with self.app.test_request_context("/foo", headers={
             'Accept': 'application/json; q=1, application/xml; q=.5'
         }):
-            self.assertEquals(api.mediatypes(),
+            self.assertEquals(self.api.mediatypes(),
                               ['application/json', 'application/xml'])
 
     def test_decorator(self):
@@ -561,9 +517,6 @@ class APITestCase(unittest.TestCase):
         view.as_view.assert_called_with('bar')
 
     def test_add_two_conflicting_resources_on_same_endpoint(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
         class Foo1(flask_restful.Resource):
             def get(self):
                 return 'foo1'
@@ -572,21 +525,19 @@ class APITestCase(unittest.TestCase):
             def get(self):
                 return 'foo2'
 
-        api.add_resource(Foo1, '/foo', endpoint='bar')
-        self.assertRaises(ValueError, api.add_resource, Foo2, '/foo/toto', endpoint='bar')
+        self.api.add_resource(Foo1, '/foo', endpoint='bar')
+        self.assertRaises(ValueError, self.api.add_resource, Foo2, '/foo/toto', endpoint='bar')
 
     def test_add_the_same_resource_on_same_endpoint(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
 
         class Foo1(flask_restful.Resource):
             def get(self):
                 return 'foo1'
 
-        api.add_resource(Foo1, '/foo', endpoint='bar')
-        api.add_resource(Foo1, '/foo/toto', endpoint='blah')
+        self.api.add_resource(Foo1, '/foo', endpoint='bar')
+        self.api.add_resource(Foo1, '/foo/toto', endpoint='blah')
 
-        with app.test_client() as client:
+        with self.app.test_client() as client:
             foo1 = client.get('/foo')
             self.assertEquals(foo1.data, b'"foo1"\n')
             foo2 = client.get('/foo/toto')
@@ -627,9 +578,6 @@ class APITestCase(unittest.TestCase):
                                             defaults={"bar": "baz"})
 
     def test_add_resource_forward_resource_class_parameters(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
         class Foo(flask_restful.Resource):
             def __init__(self, *args, **kwargs):
                 self.one = args[0]
@@ -638,11 +586,11 @@ class APITestCase(unittest.TestCase):
             def get(self):
                 return "{0} {1}".format(self.one, self.two)
 
-        api.add_resource(Foo, '/foo',
+        self.api.add_resource(Foo, '/foo',
                 resource_class_args=('wonderful',),
                 resource_class_kwargs={'secret_state': 'slurm'})
 
-        with app.test_client() as client:
+        with self.app.test_client() as client:
             foo = client.get('/foo')
             self.assertEquals(foo.data, b'"wonderful slurm"\n')
 
@@ -650,12 +598,8 @@ class APITestCase(unittest.TestCase):
 
         def make_empty_response():
             return {'foo': 'bar'}
-
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
-        with app.test_request_context("/foo"):
-            wrapper = api.output(make_empty_response)
+        with self.app.test_request_context("/foo"):
+            wrapper = self.api.output(make_empty_response)
             resp = wrapper()
             self.assertEquals(resp.status_code, 200)
             self.assertEquals(resp.data.decode(), '{"foo": "bar"}\n')
@@ -665,11 +609,8 @@ class APITestCase(unittest.TestCase):
         def make_empty_response():
             return flask.make_response('')
 
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
-        with app.test_request_context("/foo"):
-            wrapper = api.output(make_empty_response)
+        with self.app.test_request_context("/foo"):
+            wrapper = self.api.output(make_empty_response)
             resp = wrapper()
             self.assertEquals(resp.status_code, 200)
             self.assertEquals(resp.data.decode(), '')
@@ -746,21 +687,17 @@ class APITestCase(unittest.TestCase):
         self.assertRaises(HTTPException, lambda: flask_restful.abort(404))
 
     def test_endpoints(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-        api.add_resource(HelloWorld, '/ids/<int:id>', endpoint="hello")
-        with app.test_request_context('/foo'):
-            self.assertFalse(api._has_fr_route())
+        self.api.add_resource(HelloWorld, '/ids/<int:id>', endpoint="hello")
+        with self.app.test_request_context('/foo'):
+            self.assertFalse(self.api._has_fr_route())
 
-        with app.test_request_context('/ids/3'):
-            self.assertTrue(api._has_fr_route())
+        with self.app.test_request_context('/ids/3'):
+            self.assertTrue(self.api._has_fr_route())
 
     def test_url_for(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-        api.add_resource(HelloWorld, '/ids/<int:id>')
-        with app.test_request_context('/foo'):
-            self.assertEqual(api.url_for(HelloWorld, id=123), '/ids/123')
+        self.api.add_resource(HelloWorld, '/ids/<int:id>')
+        with self.app.test_request_context('/foo'):
+            self.assertEqual(self.api.url_for(HelloWorld, id=123), '/ids/123')
 
     def test_url_for_with_blueprint(self):
         """Verify that url_for works when an Api object is mounted on a
@@ -775,13 +712,11 @@ class APITestCase(unittest.TestCase):
             self.assertEqual(api.url_for(HelloWorld, bar='baz'), '/foo/baz')
 
     def test_fr_405(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-        api.add_resource(HelloWorld, '/ids/<int:id>', endpoint="hello")
-        app = app.test_client()
+        self.api.add_resource(HelloWorld, '/ids/<int:id>', endpoint="hello")
+        app = self.app.test_client()
         resp = app.post('/ids/3')
         self.assertEquals(resp.status_code, 405)
-        self.assertEquals(resp.content_type, api.default_mediatype)
+        self.assertEquals(resp.content_type, self.api.default_mediatype)
         # Allow can be of the form 'GET, PUT, POST'
         allow = ', '.join(set(resp.headers.get_all('Allow')))
         allow = set(method.strip() for method in allow.split(','))
@@ -790,9 +725,7 @@ class APITestCase(unittest.TestCase):
 
     def test_exception_header_forwarded(self):
         """Test that HTTPException's headers are extended properly"""
-        app = Flask(__name__)
-        app.config['DEBUG'] = True
-        api = flask_restful.Api(app)
+        self.app.config['DEBUG'] = True
 
         class NotModified(HTTPException):
             code = 304
@@ -809,10 +742,10 @@ class APITestCase(unittest.TestCase):
             def get(self):
                 flask_abort(304, etag='myETag')
 
-        api.add_resource(Foo1, '/foo')
+        self.api.add_resource(Foo1, '/foo')
         _aborter.mapping.update({304: NotModified})
 
-        with app.test_client() as client:
+        with self.app.test_client() as client:
             foo = client.get('/foo')
             self.assertEquals(foo.get_etag(),
                               unquote_etag(quote_etag('myETag')))
@@ -823,26 +756,21 @@ class APITestCase(unittest.TestCase):
 
         https://github.com/flask-restful/flask-restful/issues/534
         """
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
-        with app.test_request_context('/'):
-            r = api.handle_error(BadRequest())
+        with self.app.test_request_context('/'):
+            r = self.api.handle_error(BadRequest())
 
         self.assertEqual(len(r.headers.getlist('Content-Length')), 1)
 
     def test_will_prettyprint_json_in_debug_mode(self):
-        app = Flask(__name__)
-        app.config['DEBUG'] = True
-        api = flask_restful.Api(app)
+        self.app.config['DEBUG'] = True
 
         class Foo1(flask_restful.Resource):
             def get(self):
                 return {'foo': 'bar', 'baz': 'asdf'}
 
-        api.add_resource(Foo1, '/foo', endpoint='bar')
+        self.api.add_resource(Foo1, '/foo', endpoint='bar')
 
-        with app.test_client() as client:
+        with self.app.test_client() as client:
             foo = client.get('/foo')
 
             # Python's dictionaries have random order (as of "new" Pythons,
@@ -864,23 +792,20 @@ class APITestCase(unittest.TestCase):
                             'sort_keys': True,
                             'separators': (', ', ': ')}
 
-        app = Flask(__name__)
-        app.config.from_object(TestConfig)
-        api = flask_restful.Api(app)
+        self.app.config.from_object(TestConfig)
 
         class Foo(flask_restful.Resource):
             def get(self):
                 return {'foo': 'bar', 'baz': 'qux'}
 
-        api.add_resource(Foo, '/foo')
+        self.api.add_resource(Foo, '/foo')
 
-        with app.test_client() as client:
+        with self.app.test_client() as client:
             data = client.get('/foo').data
 
         expected = b'{\n  "baz": "qux", \n  "foo": "bar"\n}\n'
 
         self.assertEquals(data, expected)
-
 
     def test_use_custom_jsonencoder(self):
         class CabageEncoder(JSONEncoder):
@@ -890,65 +815,55 @@ class APITestCase(unittest.TestCase):
         class TestConfig(object):
             RESTFUL_JSON = {'cls': CabageEncoder}
 
-        app = Flask(__name__)
-        app.config.from_object(TestConfig)
-        api = flask_restful.Api(app)
+        self.app.config.from_object(TestConfig)
 
         class Cabbage(flask_restful.Resource):
             def get(self):
                 return {'frob': object()}
 
-        api.add_resource(Cabbage, '/cabbage')
+        self.api.add_resource(Cabbage, '/cabbage')
 
-        with app.test_client() as client:
+        with self.app.test_client() as client:
             data = client.get('/cabbage').data
 
         expected = b'{"frob": "cabbage"}\n'
         self.assertEquals(data, expected)
 
     def test_json_with_no_settings(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
 
         class Foo(flask_restful.Resource):
             def get(self):
                 return {'foo': 'bar'}
 
-        api.add_resource(Foo, '/foo')
+        self.api.add_resource(Foo, '/foo')
 
-        with app.test_client() as client:
+        with self.app.test_client() as client:
             data = client.get('/foo').data
 
         expected = b'{"foo": "bar"}\n'
         self.assertEquals(data, expected)
 
     def test_redirect(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
         class FooResource(flask_restful.Resource):
             def get(self):
                 return redirect('/')
 
-        api.add_resource(FooResource, '/api')
+        self.api.add_resource(FooResource, '/api')
 
-        app = app.test_client()
+        app = self.app.test_client()
         resp = app.get('/api')
         self.assertEquals(resp.status_code, 302)
         self.assertEquals(resp.headers['Location'], 'http://localhost/')
 
     def test_json_float_marshalled(self):
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-
         class FooResource(flask_restful.Resource):
             fields = {'foo': flask_restful.fields.Float}
             def get(self):
                 return flask_restful.marshal({"foo": 3.0}, self.fields)
 
-        api.add_resource(FooResource, '/api')
+        self.api.add_resource(FooResource, '/api')
 
-        app = app.test_client()
+        app = self.app.test_client()
         resp = app.get('/api')
         self.assertEquals(resp.status_code, 200)
         self.assertEquals(resp.data.decode('utf-8'), '{"foo": 3.0}\n')
@@ -999,13 +914,11 @@ class APITestCase(unittest.TestCase):
             def post(self):
                 return 'post test'
 
-        app = Flask(__name__)
-
-        with app.test_request_context('/', method='POST'):
+        with self.app.test_request_context('/', method='POST'):
             r = TestResource().dispatch_request()
             assert r == 'post test'
 
-        with app.test_request_context('/', method='GET'):
+        with self.app.test_request_context('/', method='GET'):
             r = TestResource().dispatch_request()
             assert r == 'GET TEST'
 
@@ -1024,13 +937,11 @@ class APITestCase(unittest.TestCase):
             def post(self):
                 return 'post test'
 
-        app = Flask(__name__)
-
-        with app.test_request_context('/', method='POST'):
+        with self.app.test_request_context('/', method='POST'):
             r = TestResource().dispatch_request()
             assert r == 'POST TEST'
 
-        with app.test_request_context('/', method='GET'):
+        with self.app.test_request_context('/', method='GET'):
             r = TestResource().dispatch_request()
             assert r == 'GET TEST'
 

--- a/tests/test_api_with_blueprint.py
+++ b/tests/test_api_with_blueprint.py
@@ -1,15 +1,17 @@
-import unittest
-from flask import Flask, Blueprint, request
 try:
     from mock import Mock
-except:
+except ImportError:
     # python3
     from unittest.mock import Mock
+import unittest
+
 import flask
-import flask_restful
-import flask_restful.fields
+from flask import Flask, Blueprint, request
 #noinspection PyUnresolvedReferences
 from nose.tools import assert_true, assert_false  # you need it for tests in form of continuations
+
+import flask_restful
+import flask_restful.fields
 
 
 # Add a dummy Resource to verify that the app is properly set.
@@ -28,14 +30,17 @@ class GoodbyeWorld(flask_restful.Resource):
 
 class APIWithBlueprintTestCase(unittest.TestCase):
 
+    def setUp(self):
+        self.blueprint = Blueprint('test', __name__)
+        self.api = flask_restful.Api(self.blueprint)
+        self.app = Flask(__name__)
+        self.app.register_blueprint(self.blueprint)
+
+
     def test_api_base(self):
-        blueprint = Blueprint('test', __name__)
-        api = flask_restful.Api(blueprint)
-        app = Flask(__name__)
-        app.register_blueprint(blueprint)
-        self.assertEquals(api.urls, {})
-        self.assertEquals(api.prefix, '')
-        self.assertEquals(api.default_mediatype, 'application/json')
+        self.assertEquals(self.api.urls, {})
+        self.assertEquals(self.api.prefix, '')
+        self.assertEquals(self.api.default_mediatype, 'application/json')
 
     def test_api_delayed_initialization(self):
         blueprint = Blueprint('test', __name__)
@@ -46,29 +51,20 @@ class APIWithBlueprintTestCase(unittest.TestCase):
         api.add_resource(HelloWorld, '/', endpoint="hello")
 
     def test_add_resource_endpoint(self):
-        blueprint = Blueprint('test', __name__)
-        api = flask_restful.Api(blueprint)
         view = Mock(**{'as_view.return_value': Mock(__name__='test_view')})
-        api.add_resource(view, '/foo', endpoint='bar')
-        app = Flask(__name__)
-        app.register_blueprint(blueprint)
+        self.api.add_resource(view, '/foo', endpoint='bar')
         view.as_view.assert_called_with('bar')
 
     def test_add_resource_endpoint_after_registration(self):
-        blueprint = Blueprint('test', __name__)
-        api = flask_restful.Api(blueprint)
-        app = Flask(__name__)
-        app.register_blueprint(blueprint)
         view = Mock(**{'as_view.return_value': Mock(__name__='test_view')})
-        api.add_resource(view, '/foo', endpoint='bar')
+        self.api.add_resource(view, '/foo', endpoint='bar')
         view.as_view.assert_called_with('bar')
 
     def test_url_with_api_prefix(self):
-        blueprint = Blueprint('test', __name__)
-        api = flask_restful.Api(blueprint, prefix='/api')
+        api = flask_restful.Api(self.blueprint, prefix='/api')
         api.add_resource(HelloWorld, '/hi', endpoint='hello')
         app = Flask(__name__)
-        app.register_blueprint(blueprint)
+        app.register_blueprint(self.blueprint)
         with app.test_request_context('/api/hi'):
             self.assertEquals(request.endpoint, 'test.hello')
 
@@ -118,18 +114,14 @@ class APIWithBlueprintTestCase(unittest.TestCase):
             self.assertEquals(request.endpoint, 'test.hello')
 
     def test_error_routing(self):
-        blueprint = Blueprint('test', __name__)
-        api = flask_restful.Api(blueprint)
-        api.add_resource(HelloWorld(), '/hi', endpoint="hello")
-        api.add_resource(GoodbyeWorld(404), '/bye', endpoint="bye")
-        app = Flask(__name__)
-        app.register_blueprint(blueprint)
-        with app.test_request_context('/hi', method='POST'):
-            assert_true(api._should_use_fr_error_handler())
-            assert_true(api._has_fr_route())
-        with app.test_request_context('/bye'):
-            api._should_use_fr_error_handler = Mock(return_value=False)
-            assert_true(api._has_fr_route())
+        self.api.add_resource(HelloWorld(), '/hi', endpoint="hello")
+        self.api.add_resource(GoodbyeWorld(404), '/bye', endpoint="bye")
+        with self.app.test_request_context('/hi', method='POST'):
+            assert_true(self.api._should_use_fr_error_handler())
+            assert_true(self.api._has_fr_route())
+        with self.app.test_request_context('/bye'):
+            self.api._should_use_fr_error_handler = Mock(return_value=False)
+            assert_true(self.api._has_fr_route())
 
     def test_non_blueprint_rest_error_routing(self):
         blueprint = Blueprint('test', __name__)

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,11 +1,17 @@
 import unittest
+
 from flask import Flask
+from nose.tools import assert_equals, assert_true
+
 import flask_restful
 from flask_restful.utils import cors
-from nose.tools import assert_equals, assert_true
 
 
 class CORSTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.api = flask_restful.Api(self.app)
 
     def test_crossdomain(self):
 
@@ -13,12 +19,9 @@ class CORSTestCase(unittest.TestCase):
             @cors.crossdomain(origin='*')
             def get(self):
                 return "data"
+        self.api.add_resource(Foo, '/')
 
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-        api.add_resource(Foo, '/')
-
-        with app.test_client() as client:
+        with self.app.test_client() as client:
             res = client.get('/')
             assert_equals(res.status_code, 200)
             assert_equals(res.headers['Access-Control-Allow-Origin'], '*')
@@ -34,12 +37,9 @@ class CORSTestCase(unittest.TestCase):
                               expose_headers=['X-My-Header', 'X-Another-Header'])
             def get(self):
                 return "data"
+        self.api.add_resource(Foo, '/')
 
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-        api.add_resource(Foo, '/')
-
-        with app.test_client() as client:
+        with self.app.test_client() as client:
             res = client.get('/')
             assert_equals(res.status_code, 200)
             assert_true('X-MY-HEADER' in res.headers['Access-Control-Expose-Headers'])
@@ -55,12 +55,9 @@ class CORSTestCase(unittest.TestCase):
 
             def post(self):
                 return "data"
+        self.api.add_resource(Foo, '/')
 
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-        api.add_resource(Foo, '/')
-
-        with app.test_client() as client:
+        with self.app.test_client() as client:
             res = client.get('/')
             assert_equals(res.status_code, 200)
             assert_true('HEAD' in res.headers['Access-Control-Allow-Methods'])
@@ -73,12 +70,9 @@ class CORSTestCase(unittest.TestCase):
         class Foo(flask_restful.Resource):
             def get(self):
                 return "data"
+        self.api.add_resource(Foo, '/')
 
-        app = Flask(__name__)
-        api = flask_restful.Api(app)
-        api.add_resource(Foo, '/')
-
-        with app.test_client() as client:
+        with self.app.test_client() as client:
             res = client.get('/')
             assert_equals(res.status_code, 200)
             assert_true('Access-Control-Allow-Origin' not in res.headers)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,15 +1,17 @@
+from datetime import datetime
 from decimal import Decimal
 from functools import partial
-import pytz
 import unittest
+
+from flask import Flask, Blueprint
 from mock import Mock
+#noinspection PyUnresolvedReferences
+from nose.tools import assert_equals  # you need it for tests in form of continuations
+import pytz
+
 from flask_restful.fields import MarshallingException
 from flask_restful.utils import OrderedDict
 from flask_restful import fields
-from datetime import datetime, timedelta, tzinfo
-from flask import Flask, Blueprint
-#noinspection PyUnresolvedReferences
-from nose.tools import assert_equals  # you need it for tests in form of continuations
 
 
 class Foo(object):
@@ -81,6 +83,13 @@ def test_iso8601_datetime_formatters():
 
 
 class FieldsTestCase(unittest.TestCase):
+    
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
+        bp = Blueprint("foo", __name__, url_prefix="/foo")
+        bp.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
+        self.app.register_blueprint(bp)
 
     def test_decimal_trash(self):
         self.assertRaises(MarshallingException, lambda: fields.Float().output('a', {'a': 'Foo'}))
@@ -176,116 +185,82 @@ class FieldsTestCase(unittest.TestCase):
         self.assertEquals("3-whatever", field.output("foo", Foo()))
 
     def test_url_invalid_object(self):
-        app = Flask(__name__)
-        app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
         field = fields.Url("foobar")
 
-        with app.test_request_context("/"):
+        with self.app.test_request_context("/"):
             self.assertRaises(MarshallingException, lambda: field.output("hey", None))
 
     def test_url(self):
-        app = Flask(__name__)
-        app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
         field = fields.Url("foobar")
 
-        with app.test_request_context("/"):
+        with self.app.test_request_context("/"):
             self.assertEquals("/3", field.output("hey", Foo()))
 
     def test_url_absolute(self):
-        app = Flask(__name__)
-        app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
         field = fields.Url("foobar", absolute=True)
 
-        with app.test_request_context("/"):
+        with self.app.test_request_context("/"):
             self.assertEquals("http://localhost/3", field.output("hey", Foo()))
 
     def test_url_absolute_scheme(self):
         """Url.scheme should override current_request.scheme"""
-        app = Flask(__name__)
-        app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
         field = fields.Url("foobar", absolute=True, scheme='https')
 
-        with app.test_request_context("/", base_url="http://localhost"):
+        with self.app.test_request_context("/", base_url="http://localhost"):
             self.assertEquals("https://localhost/3", field.output("hey", Foo()))
 
     def test_url_without_endpoint_invalid_object(self):
-        app = Flask(__name__)
-        app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
         field = fields.Url()
 
-        with app.test_request_context("/hey"):
+        with self.app.test_request_context("/hey"):
             self.assertRaises(MarshallingException, lambda: field.output("hey", None))
 
     def test_url_without_endpoint(self):
-        app = Flask(__name__)
-        app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
         field = fields.Url()
 
-        with app.test_request_context("/hey"):
+        with self.app.test_request_context("/hey"):
             self.assertEquals("/3", field.output("hey", Foo()))
 
     def test_url_without_endpoint_absolute(self):
-        app = Flask(__name__)
-        app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
         field = fields.Url(absolute=True)
 
-        with app.test_request_context("/hey"):
+        with self.app.test_request_context("/hey"):
             self.assertEquals("http://localhost/3", field.output("hey", Foo()))
 
     def test_url_without_endpoint_absolute_scheme(self):
-        app = Flask(__name__)
-        app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
         field = fields.Url(absolute=True, scheme='https')
 
-        with app.test_request_context("/hey", base_url="http://localhost"):
+        with self.app.test_request_context("/hey", base_url="http://localhost"):
             self.assertEquals("https://localhost/3", field.output("hey", Foo()))
 
     def test_url_with_blueprint_invalid_object(self):
-        app = Flask(__name__)
-        bp = Blueprint("foo", __name__, url_prefix="/foo")
-        bp.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
-        app.register_blueprint(bp)
         field = fields.Url()
 
-        with app.test_request_context("/foo/hey"):
+        with self.app.test_request_context("/foo/hey"):
             self.assertRaises(MarshallingException, lambda: field.output("hey", None))
 
     def test_url_with_blueprint(self):
-        app = Flask(__name__)
-        bp = Blueprint("foo", __name__, url_prefix="/foo")
-        bp.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
-        app.register_blueprint(bp)
         field = fields.Url()
 
-        with app.test_request_context("/foo/hey"):
+        with self.app.test_request_context("/foo/hey"):
             self.assertEquals("/foo/3", field.output("hey", Foo()))
 
     def test_url_with_blueprint_absolute(self):
-        app = Flask(__name__)
-        bp = Blueprint("foo", __name__, url_prefix="/foo")
-        bp.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
-        app.register_blueprint(bp)
         field = fields.Url(absolute=True)
 
-        with app.test_request_context("/foo/hey"):
+        with self.app.test_request_context("/foo/hey"):
             self.assertEquals("http://localhost/foo/3", field.output("hey", Foo()))
 
     def test_url_with_blueprint_absolute_scheme(self):
-        app = Flask(__name__)
-        bp = Blueprint("foo", __name__, url_prefix="/foo")
-        bp.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
-        app.register_blueprint(bp)
         field = fields.Url(absolute=True, scheme='https')
 
-        with app.test_request_context("/foo/hey", base_url="http://localhost"):
+        with self.app.test_request_context("/foo/hey", base_url="http://localhost"):
             self.assertEquals("https://localhost/foo/3", field.output("hey", Foo()))
 
     def test_url_superclass_kwargs(self):
-        app = Flask(__name__)
-        app.add_url_rule("/<hey>", "foobar", view_func=lambda x: x)
         field = fields.Url(absolute=True, attribute='hey')
 
-        with app.test_request_context("/hey"):
+        with self.app.test_request_context("/hey"):
             self.assertEquals("http://localhost/3", field.output("hey", Foo()))
 
     def test_int(self):

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1,11 +1,12 @@
-from datetime import datetime, timedelta, tzinfo
-import unittest
-import pytz
+from datetime import datetime
 import re
+import unittest
 
 #noinspection PyUnresolvedReferences
 from nose.tools import assert_equal, assert_raises  # you need it for tests in form of continuations
+import pytz
 import six
+
 
 from flask_restful import inputs
 
@@ -421,6 +422,7 @@ def test_bad_isointervals():
             inputs.iso8601interval,
             bad_interval,
         )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is a superficial refactor of the tests to be a bit more streamlined
by removing obvious repetition from the test classes. Most of this is
done by simply adding a Flask app instance with an API in the setUp
method of the TestCase classes. The tests in terms of what they do have
been unchanged.

This provides slightly simpler code to read - and provides new tests
with pre setup app and api instances if needed.

Also a minor refactor of import orderings in tests to match PEP8.

This was done as a colleague of mine had been building unit tests based off of the ones in flask-restful, leading to a conversation about reducing repetition in tests and making them more readable.

I note there was also a PR to move to pytest (https://github.com/flask-restful/flask-restful/pull/704) which was rejected. Considering nose has been deprecated for years and that pytest generally results in smaller and simpler tests, is there a reason it was rejected?

I'd be happy to redo this PR with pytest as an example.