### PR TITLE
Fix for #843

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -264,11 +264,11 @@ class Api(object):
         :type e: Exception
 
         """
-        if self._has_fr_route():
-            try:
+        try:
+            if self._has_fr_route():
                 return self.handle_error(e)
-            except Exception:
-                pass  # Fall through to original handler
+        except Exception:
+            pass  # Fall through to original handler
         return original_handler(e)
 
     def handle_error(self, e):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -151,6 +151,17 @@ class APITestCase(unittest.TestCase):
         self.assertEquals(resp.status_code, 403)
         self.assertDictEqual(resp_dict, {})
 
+    def test_handle_error_does_not_barf_on_bogus_method_and_redirect(self):
+
+        app = Flask(__name__)
+        api = flask_restful.Api(app)
+        api.add_resource(HelloWorld, '/hello/')
+
+        app = app.test_client()
+        resp = app.open('/hello', method='FOOBAR')
+
+        self.assertEquals(resp.status_code, 405)
+
     def test_marshal(self):
         fields = OrderedDict([('foo', flask_restful.fields.Raw)])
         marshal_dict = OrderedDict([('foo', 'bar'), ('bat', 'baz')])


### PR DESCRIPTION
Fix for #843 

Given this sample code:

```python
from flask import Flask
from flask_restful import Resource, Api

app = Flask(__name__)
api = Api(app)

class HelloWorld(Resource):
    def get(self):
        return {'hello': 'world'}

api.add_resource(HelloWorld, '/hello/')

if __name__ == '__main__':
    app.run(debug=True)
```

And this invocation from the command line using HTTPie:
```
http FOOBAR :5000/hello
```

Yields a 500 error. Expectation is a 405 as `FOOBAR` is a bogus method.
The pairing of a bogus HTTP method with a redirect from the missing
trailing slash appears to be the input that causes this behavior.

Fix is to include `_has_fr_route()` in the try block so errors can be
propagated to the original error handler