### PR TITLE
Update json.py to accomodate JSONIFY_PRETTYPRINT_REGULAR

### DIFF
--- a/flask_restful/representations/json.py
+++ b/flask_restful/representations/json.py
@@ -12,7 +12,7 @@ def output_json(data, code, headers=None):
     # If we're in debug mode, and the indent is not set, we set it to a
     # reasonable value here.  Note that this won't override any existing value
     # that was set.  We also set the "sort_keys" value.
-    if current_app.debug or current_app.config.get("JSONIFY_PRETTYPRINT_REGULAR"):    
+    if current_app.debug or (1==1):    
         settings.setdefault('indent', 4)
         settings.setdefault('sort_keys', not PY3)
 

--- a/flask_restful/representations/json.py
+++ b/flask_restful/representations/json.py
@@ -12,7 +12,7 @@ def output_json(data, code, headers=None):
     # If we're in debug mode, and the indent is not set, we set it to a
     # reasonable value here.  Note that this won't override any existing value
     # that was set.  We also set the "sort_keys" value.
-    if current_app.config["JSONIFY_PRETTYPRINT_REGULAR"] or current_app.debug:
+    if current_app.debug or current_app.config.get("JSONIFY_PRETTYPRINT_REGULAR"):    
         settings.setdefault('indent', 4)
         settings.setdefault('sort_keys', not PY3)
 

--- a/flask_restful/representations/json.py
+++ b/flask_restful/representations/json.py
@@ -12,7 +12,7 @@ def output_json(data, code, headers=None):
     # If we're in debug mode, and the indent is not set, we set it to a
     # reasonable value here.  Note that this won't override any existing value
     # that was set.  We also set the "sort_keys" value.
-    if current_app.debug or (1==1):    
+    if current_app.debug and current_app.debug:    
         settings.setdefault('indent', 4)
         settings.setdefault('sort_keys', not PY3)
 

--- a/flask_restful/representations/json.py
+++ b/flask_restful/representations/json.py
@@ -12,7 +12,7 @@ def output_json(data, code, headers=None):
     # If we're in debug mode, and the indent is not set, we set it to a
     # reasonable value here.  Note that this won't override any existing value
     # that was set.  We also set the "sort_keys" value.
-    if current_app.debug:
+    if current_app.config["JSONIFY_PRETTYPRINT_REGULAR"] or current_app.debug:
         settings.setdefault('indent', 4)
         settings.setdefault('sort_keys', not PY3)
 

--- a/flask_restful/representations/json.py
+++ b/flask_restful/representations/json.py
@@ -12,7 +12,7 @@ def output_json(data, code, headers=None):
     # If we're in debug mode, and the indent is not set, we set it to a
     # reasonable value here.  Note that this won't override any existing value
     # that was set.  We also set the "sort_keys" value.
-    if current_app.debug and current_app.debug:    
+    if current_app.debug or current_app.config.get("JSONIFY_PRETTYPRINT_REGULAR"):
         settings.setdefault('indent', 4)
         settings.setdefault('sort_keys', not PY3)
 


### PR DESCRIPTION
Without this change, the pretty output of JSON only works when in debug mode.  With this correction, it now matches the logic that  is found in the flask package, in file flask/json/__init__.py allowing a developer to dynamically set this switch while in production to do pretty output of the JSON.