### PR TITLE
Proposed v0.3.8 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,17 @@ Flask-RESTful Changelog
 
 Here you can see the full list of changes between each Flask-RESTful release.
 
+Version 0.3.8
+-------------
+
+Released February XX, 2020
+
+- Add Python 3.8 support  ([#835](https://github.com/flask-restful/flask-restful/pull/835))
+- Fix wrongly parsed Decimal fields ([#855](https://github.com/flask-restful/flask-restful/pull/855))
+- Fix overridden response when calling abort with Response ([#817](https://github.com/flask-restful/flask-restful/pull/817))
+- Various small fixes and updates to documentation
+
+
 Version 0.3.7
 -------------
 

--- a/flask_restful/__version__.py
+++ b/flask_restful/__version__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-__version__ = '0.3.7'
+__version__ = '0.3.8'


### PR DESCRIPTION
After The conversation with @joshfriend  in #855 I took a look at the repo and figured the changes already in master after the last release v0.3.7, even the python 3.8 support alone, could potentially warrant a new release, even if there are other issues and PRs pending.

To aid with that, I have prepared the CHENGES.md file, although it needs a final modification if and when this gets accepted (the date).

Side note: The solution proposed in #855 (Installing from git, pinning one commit) does not work in environments where a pypi cache such as Artifactory or Nexus is in place.