### PR TITLE
Use flask.json as default encoder

### DIFF
--- a/flask_restful/representations/json.py
+++ b/flask_restful/representations/json.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from flask import make_response, current_app
+from flask.json import dumps
 from flask_restful.utils import PY3
-from json import dumps
 
 
 def output_json(data, code, headers=None):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -924,6 +924,56 @@ class APITestCase(unittest.TestCase):
         expected = b'{"foo": "bar"}\n'
         self.assertEquals(data, expected)
 
+    def test_use_custom_flask_jsonencoder(self):
+        class CustomFlaskEncoder(JSONEncoder):
+            def default(self, obj):
+                return 'custom_flask_encoder'
+
+        app = Flask(__name__)
+        app.json_encoder = CustomFlaskEncoder
+        api = flask_restful.Api(app)
+
+        class TestResource(flask_restful.Resource):
+            def get(self):
+                return {'json_test': object()}
+
+        api.add_resource(TestResource, '/test')
+
+        with app.test_client() as client:
+            data = client.get('/test').data
+
+        expected = b'{"json_test": "custom_flask_encoder"}\n'
+        self.assertEquals(data, expected)
+
+    def test_override_custom_flask_jsonencoder(self):
+        class CustomFlaskEncoder(JSONEncoder):
+            def default(self, obj):
+                return 'custom_flask_encoder'
+
+        class CustomFlaskRESTFulEncoder(JSONEncoder):
+            def default(self, obj):
+                return 'custom_flask_resftul_encoder'
+
+        class TestConfig(object):
+            RESTFUL_JSON = {'cls': CustomFlaskRESTFulEncoder}
+
+        app = Flask(__name__)
+        app.config.from_object(TestConfig())
+        app.json_encoder = CustomFlaskEncoder
+        api = flask_restful.Api(app)
+
+        class TestResource(flask_restful.Resource):
+            def get(self):
+                return {'json_test': object()}
+
+        api.add_resource(TestResource, '/test')
+
+        with app.test_client() as client:
+            data = client.get('/test').data
+
+        expected = b'{"json_test": "custom_flask_resftul_encoder"}\n'
+        self.assertEquals(data, expected)
+
     def test_redirect(self):
         app = Flask(__name__)
         api = flask_restful.Api(app)


### PR DESCRIPTION
Fix for #873.

Use `flask.json` instead of `json` standard library as the default JSON encoder.

Overriding behavior remains, but this adds the ability for `flask_restful` to pick up the encoder defined for the app, or the api blueprint.

```python
from flask_restful import Api
from flask import Blueprint
from flask import json

class CustomJSONEncoder(json.JSONEncoder):
    def default(self, obj):
        return 'custom_flask_encoder'

blueprint = Blueprint('test', __name__)
blueprint.json_encoder = CustomJSONEncoder
api = flask_restful.Api(blueprint)
app = Flask(__name__)
app.register_blueprint(blueprint, url_prefix='/blueprint')
```

or

```python
app = Flask(__name__)
app.json_encoder = CustomJSONEncoder
api = flask_restful.Api(app)
```