### PR TITLE
Fix import of private function for flask 2.0.0

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -11,7 +11,14 @@ from werkzeug.wrappers import Response as ResponseBase
 from flask_restful.utils import http_status_message, unpack, OrderedDict
 from flask_restful.representations.json import output_json
 import sys
-from flask.helpers import _endpoint_from_view_func
+
+try:
+    # Flask < 2.0.0
+    from flask.helpers import _endpoint_from_view_func
+except:
+    # Flask >= 2.0.0
+    from flask.scaffold import _endpoint_from_view_func
+
 from types import MethodType
 import operator
 try:


### PR DESCRIPTION
Flask commit b146a13f633b0e2e26e3b8383b3db0feb563bc83

moved `def _endpoint_from_view_func` from `src/flask/helpers.py` to `src/flask/scaffold.py`

It looks like this will be released with flask 2.0.0