### PR TITLE
fix: wrong import upstream changes

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -11,7 +11,7 @@ from werkzeug.wrappers import Response as ResponseBase
 from flask_restful.utils import http_status_message, unpack, OrderedDict
 from flask_restful.representations.json import output_json
 import sys
-from flask.helpers import _endpoint_from_view_func
+from flask.scaffold import _endpoint_from_view_func
 from types import MethodType
 import operator
 try:


### PR DESCRIPTION
Change `helpers` to `scaffold` from upstream changes here https://github.com/pallets/flask/blob/2f0c62f5e6e290843f03c1fa70817c7a3c7fd661/src/flask/scaffold.py

Closes https://github.com/flask-restful/flask-restful/issues/912