### PR TITLE
Minor change to migrate to Flask 2.0.0

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -11,7 +11,7 @@ from werkzeug.wrappers import Response as ResponseBase
 from flask_restful.utils import http_status_message, unpack, OrderedDict
 from flask_restful.representations.json import output_json
 import sys
-from flask.helpers import _endpoint_from_view_func
+from flask.scaffold import _endpoint_from_view_func
 from types import MethodType
 import operator
 try:


### PR DESCRIPTION
The `_endpoint_from_view_func` function is now in `flask.scaffold` and not `flask.helpers`.

This change works perfectly on our project.