### PR TITLE
Remove private import for flask 2.0 compatability

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -11,7 +11,6 @@ from werkzeug.wrappers import Response as ResponseBase
 from flask_restful.utils import http_status_message, unpack, OrderedDict
 from flask_restful.representations.json import output_json
 import sys
-from flask.helpers import _endpoint_from_view_func
 from types import MethodType
 import operator
 try:
@@ -156,7 +155,7 @@ class Api(object):
             rule = blueprint_setup.url_prefix + rule
         options.setdefault('subdomain', blueprint_setup.subdomain)
         if endpoint is None:
-            endpoint = _endpoint_from_view_func(view_func)
+            endpoint = view_func.__name__
         defaults = blueprint_setup.url_defaults
         if 'defaults' in options:
             defaults = dict(defaults, **options.pop('defaults'))


### PR DESCRIPTION
Closes #912 
Based on input from  #913

The referenced PR worked for me, but this removes the private import - the fundamental difference will be the lack of an assert.

```
def _endpoint_from_view_func(view_func):
    """Internal helper that returns the default endpoint for a given
    function.  This always is the function name.
    """
    assert view_func is not None, "expected view func if endpoint is not provided."
    return view_func.__name__
```

Happy to close if #913 is updated to address this!
