### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setup(
     version=version,
     license='BSD',
     url='https://www.github.com/flask-restful/flask-restful/',
+    project_urls={
+        'Source': 'https://github.com/flask-restful/flask-restful',
+    },
     author='Twilio API Team',
     author_email='help@twilio.com',
     description='Simple framework for creating REST APIs',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)