### PR TITLE
fix for #936

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -122,6 +122,8 @@ class Argument(object):
         else:
             values = MultiDict()
             for l in self.location:
+                if not request.is_json and l == 'json':
+                    continue
                 value = getattr(request, l, None)
                 if callable(value):
                     value = value()


### PR DESCRIPTION
This is an attempt to fix the issue introduced with the release of Werkzeug 2.1, which no longer returns None when asked for JSON content on a request that does not have the Content-Type header set to "application/json". 

Specifically, getattr() on line 125 in reqparse.py was looking for the default locations of json and values. This resulted in a call to json() in werkzeug.request, which in turn called get_json(). That method checks request.is_json, and now throws a BadRequest exception instead of returning None. 

Here, I am proposing that flask-restful just perform the same check on request, and if the location is "json", skip it and move on. 