### PR TITLE
Fix the tests with flask 2.1.2

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -936,7 +936,7 @@ class APITestCase(unittest.TestCase):
         app = app.test_client()
         resp = app.get('/api')
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp.headers['Location'], 'http://localhost/')
+        self.assertEqual(resp.headers['Location'], '/')
 
     def test_json_float_marshalled(self):
         app = Flask(__name__)


### PR DESCRIPTION
With the latest flask version the redirects are now relative, hence the test_api will fail. This PR fixes it.

See for example https://github.com/Flask-Middleware/flask-security/commit/3e921aec1c9926b411e12cecb3713de51665d47b