### PR TITLE
.format to fstring

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,8 +45,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Flask-RESTful'
-copyright = u'{}, Kevin Burke, Kyle Conroy, Ryan Horn, Frank Stratton, Guillaume Binet'.format(
-    date.today().year)
+copyright = f'{date.today().year}, Kevin Burke, Kyle Conroy, Ryan Horn, Frank Stratton, Guillaume Binet'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -98,7 +98,7 @@ cases where you want to reference the name in the error message. ::
 
     def odd_number(value, name):
         if value % 2 == 0:
-            raise ValueError("The parameter '{}' is not odd. You gave us the value: {}".format(name, value))
+            raise ValueError(f"The parameter '{name}' is not odd. You gave us the value: {value}")
 
         return value
 

--- a/docs/intermediate-usage.rst
+++ b/docs/intermediate-usage.rst
@@ -115,7 +115,7 @@ exercise a larger amount of options. We'll define a resource named "User". ::
         if valid_email(email_str):
             return email_str
         else:
-            raise ValueError('{} is not a valid email'.format(email_str))
+            raise ValueError(f'{email_str} is not a valid email')
 
     post_parser = reqparse.RequestParser()
     post_parser.add_argument(

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -232,7 +232,7 @@ Save this example in api.py ::
 
     def abort_if_todo_doesnt_exist(todo_id):
         if todo_id not in TODOS:
-            abort(404, message="Todo {} doesn't exist".format(todo_id))
+            abort(404, message=f"Todo {todo_id} doesn't exist")
 
     parser = reqparse.RequestParser()
     parser.add_argument('task')

--- a/examples/todo.py
+++ b/examples/todo.py
@@ -12,7 +12,7 @@ TODOS = {
 
 def abort_if_todo_doesnt_exist(todo_id):
     if todo_id not in TODOS:
-        abort(404, message="Todo {} doesn't exist".format(todo_id))
+        abort(404, message=f"Todo {todo_id} doesn't exist")
 
 parser = reqparse.RequestParser()
 parser.add_argument('task')

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -477,7 +477,7 @@ class Api(object):
         Works like :func:`flask.url_for`."""
         endpoint = resource.endpoint
         if self.blueprint:
-            endpoint = '{0}.{1}'.format(self.blueprint.name, endpoint)
+            endpoint = f'{self.blueprint.name}.{endpoint}'
         return url_for(endpoint, **values)
 
     def make_response(self, data, *args, **kwargs):
@@ -543,7 +543,7 @@ class Api(object):
 
         if self.serve_challenge_on_401:
             realm = current_app.config.get("HTTP_BASIC_AUTH_REALM", "flask-restful")
-            challenge = u"{0} realm=\"{1}\"".format("Basic", realm)
+            challenge = f'Basic realm=\"{realm}\"'
 
             response.headers['WWW-Authenticate'] = challenge
         return response

--- a/flask_restful/inputs.py
+++ b/flask_restful/inputs.py
@@ -33,9 +33,9 @@ def url(value):
     :raises: ValueError
     """
     if not url_regex.search(value):
-        message = u"{0} is not a valid URL".format(value)
+        message = f"{value} is not a valid URL"
         if url_regex.search('http://' + value):
-            message += u". Did you mean: http://{0}".format(value)
+            message += f". Did you mean: http://{value}"
         raise ValueError(message)
     return value
 
@@ -63,7 +63,7 @@ class regex(object):
 
     def __call__(self, value):
         if not self.re.search(value):
-            message = 'Value does not match pattern: "{0}"'.format(self.pattern)
+            message = f'Value does not match pattern: "{self.pattern}"'
             raise ValueError(message)
         return value
 
@@ -177,8 +177,8 @@ def iso8601interval(value, argument='argument'):
 
     except ValueError:
         raise ValueError(
-            "Invalid {arg}: {value}. {arg} must be a valid ISO8601 "
-            "date/time interval.".format(arg=argument, value=value),
+            f"Invalid {argument}: {value}. {argument} must be a valid ISO8601 "
+            "date/time interval.",
         )
 
     return start, end
@@ -194,15 +194,15 @@ def _get_integer(value):
     try:
         return int(value)
     except (TypeError, ValueError):
-        raise ValueError('{0} is not a valid integer'.format(value))
+        raise ValueError(f'{value} is not a valid integer')
 
 
 def natural(value, argument='argument'):
     """ Restrict input type to the natural numbers (0, 1, 2, 3...) """
     value = _get_integer(value)
     if value < 0:
-        error = ('Invalid {arg}: {value}. {arg} must be a non-negative '
-                 'integer'.format(arg=argument, value=value))
+        error = (f'Invalid {argument}: {value}. {argument} must be a non-negative '
+                 'integer')
         raise ValueError(error)
     return value
 
@@ -211,8 +211,8 @@ def positive(value, argument='argument'):
     """ Restrict input type to the positive integers (1, 2, 3...) """
     value = _get_integer(value)
     if value < 1:
-        error = ('Invalid {arg}: {value}. {arg} must be a positive '
-                 'integer'.format(arg=argument, value=value))
+        error = (f'Invalid {argument}: {value}. {argument} must be a positive '
+                 'integer')
         raise ValueError(error)
     return value
 
@@ -227,8 +227,7 @@ class int_range(object):
     def __call__(self, value):
         value = _get_integer(value)
         if value < self.low or value > self.high:
-            error = ('Invalid {arg}: {val}. {arg} must be within the range {lo} - {hi}'
-                     .format(arg=self.argument, val=value, lo=self.low, hi=self.high))
+            error = (f'Invalid {self.argument}: {value}. {self.argument} must be within the range {self.low} - {self.high}')
             raise ValueError(error)
 
         return value
@@ -251,7 +250,7 @@ def boolean(value):
         return True
     if value in ('false', '0',):
         return False
-    raise ValueError("Invalid literal for boolean(): {0}".format(value))
+    raise ValueError(f"Invalid literal for boolean(): {value}")
 
 
 def datetime_from_rfc822(datetime_str):

--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -99,15 +99,12 @@ class Argument(object):
             choices.append(self.choices[-1])
         else:
             choices = self.choices
-        return 'Name: {0}, type: {1}, choices: {2}'.format(self.name, self.type, choices)
+        return f'Name: {self.name}, type: {self.type}, choices: {choices}'
 
     def __repr__(self):
-        return "{0}('{1}', default={2}, dest={3}, required={4}, ignore={5}, location={6}, " \
-               "type=\"{7}\", choices={8}, action='{9}', help={10}, case_sensitive={11}, " \
-               "operators={12}, store_missing={13}, trim={14}, nullable={15})".format(
-                self.__class__.__name__, self.name, self.default, self.dest, self.required, self.ignore, self.location,
-                self.type, self.choices, self.action, self.help, self.case_sensitive,
-                self.operators, self.store_missing, self.trim, self.nullable)
+        return f"{self.__class__.__name__}('{self.name}', default={self.default}, dest={self.dest}, required={self.required}, ignore={self.ignore}, location={self.location}, " \
+               "type=\"{self.type}\", choices={self.choices}, action='{self.action}', help={self.help}, case_sensitive={self.case_sensitive}, " \
+               "operators={self.operators}, store_missing={self.store_missing}, trim={self.trim}, nullable={self.nullable})"
 
     def source(self, request):
         """Pulls values off the request in the provided location
@@ -220,11 +217,9 @@ class Argument(object):
                     if self.choices and value not in self.choices:
                         if current_app.config.get("BUNDLE_ERRORS", False) or bundle_errors:
                             return self.handle_validation_error(
-                                ValueError(u"{0} is not a valid choice".format(
-                                    value)), bundle_errors)
+                                ValueError(f"{value} is not a valid choice"), bundle_errors)
                         self.handle_validation_error(
-                                ValueError(u"{0} is not a valid choice".format(
-                                    value)), bundle_errors)
+                                ValueError(f"{value} is not a valid choice"), bundle_errors)
 
                     if name in request.unparsed_arguments:
                         request.unparsed_arguments.pop(name)
@@ -232,15 +227,11 @@ class Argument(object):
 
         if not results and self.required:
             if isinstance(self.location, six.string_types):
-                error_msg = u"Missing required parameter in {0}".format(
-                    _friendly_location.get(self.location, self.location)
-                )
+                error_msg = f"Missing required parameter in {_friendly_location.get(self.location, self.location)}"
             else:
                 friendly_locations = [_friendly_location.get(loc, loc)
                                       for loc in self.location]
-                error_msg = u"Missing required parameter in {0}".format(
-                    ' or '.join(friendly_locations)
-                )
+                error_msg = f"Missing required parameter in {' or '.join(friendly_locations)}"
             if current_app.config.get("BUNDLE_ERRORS", False) or bundle_errors:
                 return self.handle_validation_error(ValueError(error_msg), bundle_errors)
             self.handle_validation_error(ValueError(error_msg), bundle_errors)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -637,7 +637,7 @@ class APITestCase(unittest.TestCase):
                 self.two = kwargs['secret_state']
 
             def get(self):
-                return "{0} {1}".format(self.one, self.two)
+                return f"{self.one} {self.two}"
 
         api.add_resource(Foo, '/foo',
                 resource_class_args=('wonderful',),

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -62,7 +62,7 @@ def check_bad_url_raises(value):
         inputs.url(value)
         assert False, "shouldn't get here"
     except ValueError as e:
-        assert_equal(six.text_type(e), u"{0} is not a valid URL".format(value))
+        assert_equal(six.text_type(e), f"{value} is not a valid URL")
 
 
 def test_bad_urls():
@@ -102,10 +102,10 @@ def test_bad_url_error_message():
 def check_url_error_message(value):
     try:
         inputs.url(value)
-        assert False, u"inputs.url({0}) should raise an exception".format(value)
+        assert False, f"inputs.url({value}) should raise an exception"
     except ValueError as e:
         assert_equal(six.text_type(e),
-                     (u"{0} is not a valid URL. Did you mean: http://{0}".format(value)))
+                     (f"{value} is not a valid URL. Did you mean: http://{value}"))
 
 
 def test_regex_bad_input():

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -693,8 +693,8 @@ class ReqParseTestCase(unittest.TestCase):
     def test_filestorage_custom_type(self):
         def _custom_type(f):
             return FileStorage(stream=f.stream,
-                               filename="{0}aaaa".format(f.filename),
-                               name="{0}aaaa".format(f.name))
+                               filename=f"{f.filename}aaaa",
+                               name=f"{f.name}aaaa")
 
         app = Flask(__name__)
 


### PR DESCRIPTION
in Python 3.6 and later, you can use f-Strings instead. f-Strings, also called formatted string literals, have a more succinct syntax and can be super helpful in string formatting