### PR TITLE
Flask-RESTful will fail when Flask deprecates propagate_exceptions: Fix

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -10,15 +10,13 @@ from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound, NotAc
 from werkzeug.wrappers import Response as ResponseBase
 from flask_restful.utils import http_status_message, unpack, OrderedDict
 from flask_restful.representations.json import output_json
-
+import sys
 from types import MethodType
 import operator
 try:
     from collections.abc import Mapping
 except ImportError:
     from collections import Mapping
-
-import sys
 
 _PROPAGATE_EXCEPTIONS = 'PROPAGATE_EXCEPTIONS'
 

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -41,7 +41,7 @@ def abort(http_status_code, **kwargs):
 def _get_propagate_exceptions_bool(app):
     """Handle Flask's propagate_exceptions.
 
-    If propagate_exceptions is set to True the exceptions are re-raised rather than being handled
+    If propagate_exceptions is set to True then the exceptions are re-raised rather than being handled
     by the app’s error handlers. The behavior here checks whether either TESTING or DEBUG has been set
     to True, and if so, propagate_exceptions is set to True.
     """

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -42,6 +42,9 @@ def _get_propagate_exceptions_bool(app):
     If propagate_exceptions is set to True then the exceptions are re-raised rather than being handled
     by the app’s error handlers. The behavior here checks whether either TESTING or DEBUG has been set
     to True, and if so, propagate_exceptions is set to True.
+
+    The default value for Flask's app.config['PROPAGATE_EXCEPTIONS'] is None, and is handled appropriately
+    here in the code: as if it was False.
     """
     propagate = app.config.get(_PROPAGATE_EXCEPTIONS, False)
     debug = app.debug

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -42,10 +42,13 @@ def _get_propagate_exceptions_bool(app):
     If propagate_exceptions is set to True then the exceptions are re-raised rather than being handled
     by the app’s error handlers.
 
-    The default value for Flask's app.config['PROPAGATE_EXCEPTIONS'] is None, however will never be returned.
-    Instead, a sensible value is returned: self.testing or self.debug.
+    The default value for Flask's app.config['PROPAGATE_EXCEPTIONS'] is None. In this case return a sensible
+    value: self.testing or self.debug.
     """
-    return app.config.get(_PROPAGATE_EXCEPTIONS, False)
+    propagate_exceptions = app.config.get(_PROPAGATE_EXCEPTIONS, False)
+    if propagate_exceptions is None:
+        return app.testing or app.debug
+    return propagate_exceptions
 
 
 def _handle_flask_propagate_exceptions_config(app, e):

--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -40,17 +40,12 @@ def _get_propagate_exceptions_bool(app):
     """Handle Flask's propagate_exceptions.
 
     If propagate_exceptions is set to True then the exceptions are re-raised rather than being handled
-    by the app’s error handlers. The behavior here checks whether either TESTING or DEBUG has been set
-    to True, and if so, propagate_exceptions is set to True.
+    by the app’s error handlers.
 
-    The default value for Flask's app.config['PROPAGATE_EXCEPTIONS'] is None, and is handled appropriately
-    here in the code: as if it was False.
+    The default value for Flask's app.config['PROPAGATE_EXCEPTIONS'] is None, however will never be returned.
+    Instead, a sensible value is returned: self.testing or self.debug.
     """
-    propagate = app.config.get(_PROPAGATE_EXCEPTIONS, False)
-    debug = app.debug
-    testing = app.testing
-    propagate_exceptions = debug or testing or propagate
-    return propagate_exceptions
+    return app.config.get(_PROPAGATE_EXCEPTIONS, False)
 
 
 def _handle_flask_propagate_exceptions_config(app, e):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -136,7 +136,6 @@ class APITestCase(unittest.TestCase):
         mock_sys_exc_info.return_value = (KeyError, ValueError, Exception.__traceback__)
         with setup.app.test_request_context(_APP_ENDPOINT):
             self.assertRaises(KeyError, setup.api.handle_error, KeyError)
-            self.assertTrue(True)
 
     @patch(_FLASK_RESTFUL_SYS_EXC_INFO)
     def test_handle_error_propagate_exceptions2(self, mock_sys_exc_info):
@@ -144,7 +143,6 @@ class APITestCase(unittest.TestCase):
         mock_sys_exc_info.return_value = (KeyError, ValueError, Exception.__traceback__)
         with setup.app.test_request_context(_APP_ENDPOINT):
             self.assertRaises(Exception, setup.api.handle_error, ValueError)
-            self.assertTrue(True)
 
     def test_handle_error_does_not_swallow_custom_exceptions(self):
         app = Flask(__name__)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -131,16 +131,24 @@ class APITestCase(unittest.TestCase):
             self.assertEqual(resp.get_data(), b'{"message": "x"}\n')
 
     @patch(_FLASK_RESTFUL_SYS_EXC_INFO)
-    def test_handle_error_propagate_exceptions(self, mock_sys_exc_info):
+    def test_handle_error_propagate_exceptions_raise_exception(self, mock_sys_exc_info):
         setup = setup_propagate_exceptions(True)
         mock_sys_exc_info.return_value = (KeyError, ValueError, Exception.__traceback__)
         with setup.app.test_request_context(_APP_ENDPOINT):
             self.assertRaises(KeyError, setup.api.handle_error, KeyError)
 
     @patch(_FLASK_RESTFUL_SYS_EXC_INFO)
-    def test_handle_error_propagate_exceptions2(self, mock_sys_exc_info):
+    def test_handle_error_propagate_exceptions_raise(self, mock_sys_exc_info):
         setup = setup_propagate_exceptions(True)
         mock_sys_exc_info.return_value = (KeyError, ValueError, Exception.__traceback__)
+        with setup.app.test_request_context(_APP_ENDPOINT):
+            self.assertRaises(Exception, setup.api.handle_error, ValueError)
+
+    @patch(_FLASK_RESTFUL_SYS_EXC_INFO)
+    def test_handle_error_propagate_exceptions_none(self, mock_sys_exc_info):
+        setup = setup_propagate_exceptions(None)
+        mock_sys_exc_info.return_value = (KeyError, ValueError, Exception.__traceback__)
+        setup.app.debug = True
         with setup.app.test_request_context(_APP_ENDPOINT):
             self.assertRaises(Exception, setup.api.handle_error, ValueError)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,19 @@ from flask_restful import OrderedDict
 from json import dumps, loads, JSONEncoder
 from nose.tools import assert_equal  # you need it for tests in form of continuations
 import six
+from types import SimpleNamespace
+from unittest.mock import patch
+
+_FLASK_RESTFUL_SYS_EXC_INFO = 'flask_restful.sys.exc_info'
+_PROPAGATE_EXCEPTIONS = 'PROPAGATE_EXCEPTIONS'
+_APP_ENDPOINT = '/foo'
+
+
+def setup_propagate_exceptions(propagate_exceptions):
+    app = Flask(__name__)
+    app.config[_PROPAGATE_EXCEPTIONS] = propagate_exceptions
+    api = flask_restful.Api(app)
+    return SimpleNamespace(app=app, api=api)
 
 
 def check_unpack(expected, value):
@@ -117,6 +130,21 @@ class APITestCase(unittest.TestCase):
             self.assertEqual(resp.status_code, 400)
             self.assertEqual(resp.get_data(), b'{"message": "x"}\n')
 
+    @patch(_FLASK_RESTFUL_SYS_EXC_INFO)
+    def test_handle_error_propagate_exceptions(self, mock_sys_exc_info):
+        setup = setup_propagate_exceptions(True)
+        mock_sys_exc_info.return_value = (KeyError, ValueError, Exception.__traceback__)
+        with setup.app.test_request_context(_APP_ENDPOINT):
+            self.assertRaises(KeyError, setup.api.handle_error, KeyError)
+            self.assertTrue(True)
+
+    @patch(_FLASK_RESTFUL_SYS_EXC_INFO)
+    def test_handle_error_propagate_exceptions2(self, mock_sys_exc_info):
+        setup = setup_propagate_exceptions(True)
+        mock_sys_exc_info.return_value = (KeyError, ValueError, Exception.__traceback__)
+        with setup.app.test_request_context(_APP_ENDPOINT):
+            self.assertRaises(Exception, setup.api.handle_error, ValueError)
+            self.assertTrue(True)
 
     def test_handle_error_does_not_swallow_custom_exceptions(self):
         app = Flask(__name__)


### PR DESCRIPTION
## Handle the deprecation of Flask's propagate_exceptions

### Overview of the Issue in Flask-RESTful

Flasks `app.propagate_exceptions` will be deprecated in the next release, and although the Flask developers don't have a release date, given their release history it may be sooner rather than later. If it is deprecated Flask-RESTful will throw an exception in `flask_restul.__init__` in the handle_errors method. This is the only place in Flask-RESTful where this
attribute is accessed.

This pull request addresses the need to fix this issue in Flask-RESTful. Along with the fix I cleaned up that area of the code a bit, and made a few minor style changes, e.g., fixing a typo, removing an extra line feed, etc. Unit tests were added and pass. 

Currently in Flask, if `app.propagate_exceptions` is set to True then the exceptions are re-raised rather than being handled by the app’s error handlers. When `app.propagate_exceptions` is deprecated `app.config['PROPAGATE_EXCEPTIONS']` may be used in its place. Additionally, if `app.propagate_exceptions` is None (default value), then a sensible value should be substituted.

### Relevant Flask Documentation
[Flask Config Docs](https://flask.palletsprojects.com/en/2.2.x/config/)

### Relevant Flask Pull Requests
[#4716: deprecate most config attributes (fixed by #4722)](https://github.com/pallets/flask/issues/4716)
[#4722: deprecate most config attributes (merged)](https://github.com/pallets/flask/pull/4722)