### PR TITLE
replace use `nose` by `pytest`

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -15,12 +15,12 @@ You can run on all supported versions with::
 
 Individual tests can be run using a command with the format::
 
-    nosetests <filename>:ClassName.func_name
+    pytest <filename>:ClassName.func_name
 
 Example::
 
     $ source env/bin/activate
-    $ nosetests tests/test_reqparse.py:ReqParseTestCase.test_parse_choices_insensitive
+    $ pytest tests/test_reqparse.py:ReqParseTestCase.test_parse_choices_insensitive
 
 Alternately, if you push changes to your fork on Github, Travis will run the tests
 for your branch automatically.

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,4 +2,4 @@
 
 Go to main directory and type:
 
-    python2 setup.py test
+    pyttest

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,4 +2,4 @@
 
 Go to main directory and type:
 
-    pyttest
+    pytest

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,6 @@
 
 import functools
 
-from nose import SkipTest
 
 
 def expected_failure(test):

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
-nose>=1.1.2
-mock>=0.8
-nosexcover
 blinker
+mock>=0.8
+pytest

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,7 +16,6 @@ import flask_restful
 import flask_restful.fields
 from flask_restful import OrderedDict
 from json import dumps, loads, JSONEncoder
-from nose.tools import assert_equal  # you need it for tests in form of continuations
 import six
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -34,7 +33,7 @@ def setup_propagate_exceptions(propagate_exceptions):
 
 
 def check_unpack(expected, value):
-    assert_equal(expected, value)
+    assert expected == value
 
 
 def test_unpack():

--- a/tests/test_api_with_blueprint.py
+++ b/tests/test_api_with_blueprint.py
@@ -9,7 +9,6 @@ import flask
 import flask_restful
 import flask_restful.fields
 #noinspection PyUnresolvedReferences
-from nose.tools import assert_true, assert_false  # you need it for tests in form of continuations
 
 
 # Add a dummy Resource to verify that the app is properly set.
@@ -125,11 +124,11 @@ class APIWithBlueprintTestCase(unittest.TestCase):
         app = Flask(__name__)
         app.register_blueprint(blueprint)
         with app.test_request_context('/hi', method='POST'):
-            assert_true(api._should_use_fr_error_handler())
-            assert_true(api._has_fr_route())
+            assert api._should_use_fr_error_handler()
+            assert api._has_fr_route()
         with app.test_request_context('/bye'):
             api._should_use_fr_error_handler = Mock(return_value=False)
-            assert_true(api._has_fr_route())
+            assert api._has_fr_route()
 
     def test_non_blueprint_rest_error_routing(self):
         blueprint = Blueprint('test', __name__)
@@ -142,23 +141,23 @@ class APIWithBlueprintTestCase(unittest.TestCase):
         api2.add_resource(HelloWorld(), '/hi', endpoint="hello")
         api2.add_resource(GoodbyeWorld(404), '/bye', endpoint="bye")
         with app.test_request_context('/hi', method='POST'):
-            assert_false(api._should_use_fr_error_handler())
-            assert_true(api2._should_use_fr_error_handler())
-            assert_false(api._has_fr_route())
-            assert_true(api2._has_fr_route())
+            assert not api._should_use_fr_error_handler()
+            assert api2._should_use_fr_error_handler()
+            assert not api._has_fr_route()
+            assert api2._has_fr_route()
         with app.test_request_context('/blueprint/hi', method='POST'):
-            assert_true(api._should_use_fr_error_handler())
-            assert_false(api2._should_use_fr_error_handler())
-            assert_true(api._has_fr_route())
-            assert_false(api2._has_fr_route())
+            assert api._should_use_fr_error_handler()
+            assert not api2._should_use_fr_error_handler()
+            assert api._has_fr_route()
+            assert not api2._has_fr_route()
         api._should_use_fr_error_handler = Mock(return_value=False)
         api2._should_use_fr_error_handler = Mock(return_value=False)
         with app.test_request_context('/bye'):
-            assert_false(api._has_fr_route())
-            assert_true(api2._has_fr_route())
+            assert not api._has_fr_route()
+            assert api2._has_fr_route()
         with app.test_request_context('/blueprint/bye'):
-            assert_true(api._has_fr_route())
-            assert_false(api2._has_fr_route())
+            assert api._has_fr_route()
+            assert not api2._has_fr_route()
 
     def test_non_blueprint_non_rest_error_routing(self):
         blueprint = Blueprint('test', __name__)
@@ -176,16 +175,16 @@ class APIWithBlueprintTestCase(unittest.TestCase):
         def bye():
             flask.abort(404)
         with app.test_request_context('/hi', method='POST'):
-            assert_false(api._should_use_fr_error_handler())
-            assert_false(api._has_fr_route())
+            assert not api._should_use_fr_error_handler()
+            assert not api._has_fr_route()
         with app.test_request_context('/blueprint/hi', method='POST'):
-            assert_true(api._should_use_fr_error_handler())
-            assert_true(api._has_fr_route())
+            assert api._should_use_fr_error_handler()
+            assert api._has_fr_route()
         api._should_use_fr_error_handler = Mock(return_value=False)
         with app.test_request_context('/bye'):
-            assert_false(api._has_fr_route())
+            assert not api._has_fr_route()
         with app.test_request_context('/blueprint/bye'):
-            assert_true(api._has_fr_route())
+            assert api._has_fr_route()
 
 
 if __name__ == '__main__':

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -9,7 +9,6 @@ from flask_restful import fields
 from datetime import datetime, timedelta, tzinfo
 from flask import Flask, Blueprint
 #noinspection PyUnresolvedReferences
-from nose.tools import assert_equals  # you need it for tests in form of continuations
 
 
 class Foo(object):
@@ -23,7 +22,7 @@ class Bar(object):
 
 
 def check_field(expected, field, value):
-    assert_equals(expected, field.output('a', {'a': value}))
+    assert expected == field.output('a', {'a': value})
 
 
 def test_float():

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -4,7 +4,6 @@ import pytz
 import re
 
 #noinspection PyUnresolvedReferences
-from nose.tools import assert_equal, assert_raises  # you need it for tests in form of continuations
 import six
 
 from flask_restful import inputs
@@ -62,7 +61,7 @@ def check_bad_url_raises(value):
         inputs.url(value)
         assert False, "shouldn't get here"
     except ValueError as e:
-        assert_equal(six.text_type(e), u"{0} is not a valid URL".format(value))
+        assert six.text_type(e) == u"{0} is not a valid URL".format(value)
 
 
 def test_bad_urls():
@@ -104,7 +103,7 @@ def check_url_error_message(value):
         inputs.url(value)
         assert False, u"inputs.url({0}) should raise an exception".format(value)
     except ValueError as e:
-        assert_equal(six.text_type(e),
+        assert (six.text_type(e) ==
                      (u"{0} is not a valid URL. Did you mean: http://{0}".format(value)))
 
 
@@ -168,53 +167,53 @@ def test_regex_flags_bad_input():
 class TypesTestCase(unittest.TestCase):
 
     def test_boolean_false(self):
-        assert_equal(inputs.boolean("False"), False)
+        assert inputs.boolean("False") == False
 
     def test_boolean_is_false_for_0(self):
-        assert_equal(inputs.boolean("0"), False)
+        assert inputs.boolean("0") == False
 
     def test_boolean_true(self):
-        assert_equal(inputs.boolean("true"), True)
+        assert inputs.boolean("true") == True
 
     def test_boolean_is_true_for_1(self):
-        assert_equal(inputs.boolean("1"), True)
+        assert inputs.boolean("1") == True
 
     def test_boolean_upper_case(self):
-        assert_equal(inputs.boolean("FaLSE"), False)
+        assert inputs.boolean("FaLSE") == False
 
     def test_boolean(self):
-        assert_equal(inputs.boolean("FaLSE"), False)
+        assert inputs.boolean("FaLSE") == False
 
     def test_boolean_with_python_bool(self):
         """Input that is already a native python `bool` should be passed through
         without extra processing."""
-        assert_equal(inputs.boolean(True), True)
-        assert_equal(inputs.boolean(False), False)
+        assert inputs.boolean(True) == True
+        assert inputs.boolean(False) == False
 
     def test_bad_boolean(self):
         assert_raises(ValueError, lambda: inputs.boolean("blah"))
 
     def test_date_later_than_1900(self):
-        assert_equal(inputs.date("1900-01-01"), datetime(1900, 1, 1))
+        assert inputs.date("1900-01-01") == datetime(1900, 1, 1)
 
     def test_date_input_error(self):
         assert_raises(ValueError, lambda: inputs.date("2008-13-13"))
 
     def test_date_input(self):
-        assert_equal(inputs.date("2008-08-01"), datetime(2008, 8, 1))
+        assert inputs.date("2008-08-01") == datetime(2008, 8, 1)
 
     def test_natual_negative(self):
         assert_raises(ValueError, lambda: inputs.natural(-1))
 
     def test_natural(self):
-        assert_equal(3, inputs.natural(3))
+        assert 3 == inputs.natural(3)
 
     def test_natual_string(self):
         assert_raises(ValueError, lambda: inputs.natural('foo'))
 
     def test_positive(self):
-        assert_equal(1, inputs.positive(1))
-        assert_equal(10000, inputs.positive(10000))
+        assert 1 == inputs.positive(1)
+        assert 10000 == inputs.positive(10000)
 
     def test_positive_zero(self):
         assert_raises(ValueError, lambda: inputs.positive(0))
@@ -224,11 +223,11 @@ class TypesTestCase(unittest.TestCase):
 
     def test_int_range_good(self):
         int_range = inputs.int_range(1, 5)
-        assert_equal(3, int_range(3))
+        assert 3 == int_range(3)
 
     def test_int_range_inclusive(self):
         int_range = inputs.int_range(1, 5)
-        assert_equal(5, int_range(5))
+        assert 5 == int_range(5)
 
     def test_int_range_low(self):
         int_range = inputs.int_range(0, 5)
@@ -397,11 +396,10 @@ def test_invalid_isointerval_error():
     try:
         inputs.iso8601interval('2013-01-01/blah')
     except ValueError as error:
-        assert_equal(
-            str(error),
+        assert (
+            str(error) ==
             "Invalid argument: 2013-01-01/blah. argument must be a valid ISO8601 "
-            "date/time interval.",
-        )
+            "date/time interval.")
         return
     assert False, 'Should raise a ValueError'
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,6 @@ deps =
 usedevelop = true
 commands =
     pip install -e .
-    nosetests
+    pytest
 deps =
     -r{toxinidir}/tests/requirements.txt


### PR DESCRIPTION
Drop use `nose` and replace it by `pytesr` using `nose2pytest` module
+ some manual changes.

`nose` is deprecated and hould not be used with python 3.x https://nose.readthedocs.io/en/latest/
