### PR TITLE
Fix Initialization Issue with Api Class When Using init_app

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -118,8 +118,7 @@ class Api(object):
         self.app = None
         self.blueprint = None
 
-        if app is not None:
-            self.app = app
+        if app is not None:          
             self.init_app(app)
 
     def init_app(self, app):
@@ -137,6 +136,7 @@ class Api(object):
             api.init_app(app)
 
         """
+        self.app = app  # Set the app here
         # If app is a blueprint, defer the initialization
         try:
             app.record(self._deferred_blueprint_init)


### PR DESCRIPTION
### Problem Description
Currently, when a user creates an Api instance without passing the app argument (i.e., api = Api()), and later initializes it with api.init_app(app), the app is not set correctly. This issue arises because self.app is not set in init_app, but only in __init__.

### Proposed Changes
I propose a change in the Api class where self.app = app is moved from the __init__ method to the init_app method. 


