### PR TITLE
Update quickstart.rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -235,7 +235,7 @@ Save this example in api.py ::
             abort(404, message="Todo {} doesn't exist".format(todo_id))
 
     parser = reqparse.RequestParser()
-    parser.add_argument('task')
+    parser.add_argument('task', location='form')
 
 
     # Todo


### PR DESCRIPTION
I tried running the larger example in the Quick Start section and ran into issues with POST and PUT examples:

**POST**
```
curl http://localhost:5000/todos -d "task=something new" -X POST -v
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying [::1]:5000...
* connect to ::1 port 5000 failed: Connection refused
*   Trying 127.0.0.1:5000...
* Connected to localhost (127.0.0.1) port 5000
> POST /todos HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/8.4.0
> Accept: */*
> Content-Length: 18
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.1 415 UNSUPPORTED MEDIA TYPE
< Server: Werkzeug/3.0.1 Python/3.11.5
< Date: Tue, 13 Feb 2024 18:59:14 GMT
< Content-Type: application/json
< Content-Length: 116
< Connection: close
< 
{
    "message": "Did not attempt to load JSON data because the request Content-Type was not 'application/json'."
}
* Closing connection

```

**PUT**
```
curl http://localhost:5000/todos/todo3 -d "task=something different" -X PUT -v
*   Trying [::1]:5000...
* connect to ::1 port 5000 failed: Connection refused
*   Trying 127.0.0.1:5000...
* Connected to localhost (127.0.0.1) port 5000
> PUT /todos/todo3 HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/8.4.0
> Accept: */*
> Content-Length: 24
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.1 415 UNSUPPORTED MEDIA TYPE
< Server: Werkzeug/3.0.1 Python/3.11.5
< Date: Tue, 13 Feb 2024 18:59:54 GMT
< Content-Type: application/json
< Content-Length: 116
< Connection: close
< 
{
    "message": "Did not attempt to load JSON data because the request Content-Type was not 'application/json'."
}
* Closing connection
```

We have to provide the content type to the parser or the connection will be refused. This appears to be coming from https://github.com/pallets/werkzeug/commit/bf4ede275335644102cd72c421c2b6976bc69883.

