### PR TITLE
Updated for a setter method to set errors

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -146,6 +146,9 @@ class Api(object):
         else:
             self.blueprint = app
 
+    def set_errors(self, errors):
+        self.errors = errors
+
     def _complete_url(self, url_part, registration_prefix):
         """This method is used to defer the construction of the final url in
         the case that the Api is created with a Blueprint.


### PR DESCRIPTION
While working I often find myself setting custom errors like this `api.error = {...}`. This especially happened when I was using the factory method for creating an app. So I added a setter method here concerning the OOP paradigm.