### PR TITLE
Update class Api.init_app

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -127,8 +127,7 @@ class Api(object):
         application or :class:`flask.Blueprint` object.
 
         :param app: the Flask application or blueprint object
-        :type app: flask.Flask
-        :type app: flask.Blueprint
+        :type app: flask.Flask or flask.Blueprint
 
         Examples::
 


### PR DESCRIPTION
class Api
  method init_app 
    docstring

:type app: flask.Flask
:type app: flask.Blueprint

to

:type app: flask.Flask or flask.Blueprint

IDE and mypy see only last :type app: and demanded use Blueprint type