### PR TITLE
Remove json parsing if content type is not application/json

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -113,6 +113,12 @@ class Argument(object):
         """Pulls values off the request in the provided location
         :param request: The flask request object to parse arguments from
         """
+        location = self.location
+        if getattr(request, "content_type", "") != "application/json":
+            if self.location == "json":
+                return MultiDict()
+            elif "json" in self.location:
+                location = tuple(loc for loc in self.location if loc != 'json')
         if isinstance(self.location, six.string_types):
             value = getattr(request, self.location, MultiDict())
             if callable(value):
@@ -121,7 +127,7 @@ class Argument(object):
                 return value
         else:
             values = MultiDict()
-            for l in self.location:
+            for l in location:
                 value = getattr(request, l, None)
                 if callable(value):
                     value = value()

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -811,6 +811,22 @@ class ReqParseTestCase(unittest.TestCase):
                                       content_type='application/json'):
             parser.parse_args()  # Should not raise a 400: BadRequest
 
+    def test_content_type_not_json(self):
+        app = Flask(__name__)
+
+        parser = RequestParser()
+        parser.add_argument("foo")
+
+        with app.test_request_context("/bubble", method="get", data=json.dumps({"foo": "bar"})):
+            args = parser.parse_args()
+            self.assertIsNone(args.get("foo"))
+
+        with app.test_request_context("/bubble", method="get",
+                                      content_type="application/json",
+                                      data=json.dumps({"foo": "bar"})):
+            args = parser.parse_args()
+            self.assertEqual(args["foo"], "bar")
+
     def test_request_parser_remove_argument(self):
         req = Request.from_values("/bubble?foo=baz")
         parser = RequestParser()


### PR DESCRIPTION
Closes https://github.com/flask-restful/flask-restful/issues/963

This approach removes the attempt to parse json if the content type is not application/json. One one hand, this, in addition to allowing reqparse to be used with Werkzeug >= 2.1.0, matches the behavior of newer versions of Flask/Werkzeug.

On the other hand, this may introduce unexpected behavior if users pin an older version of Flask but update Flask-Restful, as they will no longer parse json when the content type is different. Backwards compatibility could be more easily maintained by handling the get_json() exception, but this seems like a less explicit solution.