### PR TITLE
allign "mock" import patterns accross tests

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,7 +2,10 @@ from decimal import Decimal
 from functools import partial
 import pytz
 import unittest
-from mock import Mock
+try:
+    from mock import Mock
+except ImportError:
+    from unittest.mock import Mock
 from flask_restful.fields import MarshallingException
 from flask_restful.utils import OrderedDict
 from flask_restful import fields

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import unittest
-from mock import Mock, patch
+try:
+    from mock import Mock, patch
+except ImportError:
+    from unittest.mock import Mock, patch
 from flask import Flask
 from werkzeug import exceptions
 from werkzeug.wrappers import Request


### PR DESCRIPTION
Hi,

I noticed the import of `mock` accross tests was inconsistent.

This will use the same pattern everywhere.